### PR TITLE
feat(GAM #10): Update logging config with file/line info and daily rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ cover/
 
 # Django stuff:
 *.log
+logs/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/gam/settings.py
+++ b/gam/settings.py
@@ -137,12 +137,15 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # Logging configuration
 # https://docs.djangoproject.com/en/6.0/topics/logging/
 
+LOG_DIR = BASE_DIR / "logs"
+LOG_DIR.mkdir(exist_ok=True)
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
         "verbose": {
-            "format": "{levelname} {asctime} {module} {message}",
+            "format": "{levelname} {asctime} {name} {filename}:{lineno} {message}",
             "style": "{",
         },
         "simple": {
@@ -155,19 +158,26 @@ LOGGING = {
             "class": "logging.StreamHandler",
             "formatter": "verbose",
         },
+        "file": {
+            "class": "logging.handlers.TimedRotatingFileHandler",
+            "filename": str(LOG_DIR / "gam.log"),
+            "when": "midnight",
+            "backupCount": 30,
+            "formatter": "verbose",
+        },
     },
     "root": {
-        "handlers": ["console"],
+        "handlers": ["console", "file"],
         "level": "WARNING",
     },
     "loggers": {
         "django": {
-            "handlers": ["console"],
+            "handlers": ["console", "file"],
             "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
             "propagate": False,
         },
         "archive": {
-            "handlers": ["console"],
+            "handlers": ["console", "file"],
             "level": os.getenv("ARCHIVE_LOG_LEVEL", "DEBUG"),
             "propagate": False,
         },


### PR DESCRIPTION
## Summary
- Add file name and line number to the verbose log formatter for easier tracing
- Add a `TimedRotatingFileHandler` that rotates at midnight daily, retaining 30 days of logs
- Add `logs/` directory to `.gitignore`

## Test plan
- [ ] Start the dev server and verify console log output includes filename and line number
- [ ] Confirm `logs/gam.log` is created on startup
- [ ] Verify log rotation by checking `TimedRotatingFileHandler` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #10