### PR TITLE
docs(GAM #247): add project documentation with Zensical and mkdocstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,129 @@
+# Griddy Archive Manager
+
+A Django 6.0+ application for cataloging and managing football game video archives across multiple levels of play (High School, College, Professional).
+
+## Overview
+
+Griddy Archive Manager (GAM) tracks games, teams, venues, and video assets using a two-domain data model:
+
+- **Catalog** — what exists: leagues, seasons, games, teams, venues, and organizational hierarchies (conferences, divisions)
+- **Holdings** — what you own: sources, acquisitions, video assets with detailed codec/quality metadata, and coverage tracking
+
+The application ingests game data from NFL.com (via the [Griddy SDK](https://github.com/Thistle-Grow-Software/griddy-sdk-python)), Sports-Reference, and Wikipedia using a hierarchy of scrapers, and exposes all data through the Django admin interface.
+
+## Quick Start
+
+### Prerequisites
+
+- Python 3.14+
+- PostgreSQL
+- [uv](https://docs.astral.sh/uv/) for dependency management
+- AWS CodeArtifact access (for the `griddy` SDK dependency)
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/Thistle-Grow-Software/all-things-griddy.git
+cd all-things-griddy/griddy-archive-manager
+
+# Install dependencies
+uv sync
+
+# Set required environment variables
+export PG_HOST=localhost
+export PG_PORT=5432
+export PG_DB_NAME=griddy
+export PG_USER=your_user
+export PG_PASSWORD=your_password
+
+# Apply database migrations
+uv run manage.py migrate
+
+# Create a superuser for the admin interface
+uv run manage.py createsuperuser
+
+# Start the development server
+uv run manage.py runserver
+```
+
+The admin interface is available at `http://localhost:8000/admin/`.
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `PG_HOST` | PostgreSQL host |
+| `PG_PORT` | PostgreSQL port |
+| `PG_DB_NAME` | PostgreSQL database name |
+| `PG_USER` | PostgreSQL user |
+| `PG_PASSWORD` | PostgreSQL password |
+| `GRIDDY_NFL_EMAIL` | NFL.com email for authenticated scraping |
+| `GRIDDY_NFL_PASSWORD` | NFL.com password for authenticated scraping |
+| `MEDIA_ROOT` | Directory for uploaded media files (team logos, etc.) |
+| `AWS_CODEARTIFACT_TOKEN` | Authentication token for AWS CodeArtifact |
+
+## Architecture
+
+### Two-Domain Data Model
+
+**Catalog domain** — game metadata and organizational structure:
+
+```
+League -> Season -> Game (home_team / away_team -> Team)
+Team -> TeamAffiliation -> OrgUnit (conferences, divisions -- hierarchical via parent)
+Franchise -> Team (groups era-specific team records)
+Venue <- TeamVenueOccupancy -> Team
+```
+
+`TeamAffiliation` supports temporal scoping by `Season` or date range to track conference realignment. `Franchise` groups multiple `Team` eras (e.g., the Baltimore Ravens franchise includes its current and historical team records).
+
+**Holdings domain** — asset management:
+
+```
+Source -> Acquisition -> VideoAsset -> Game
+Tag <- AssetTag -> VideoAsset
+GameCompleteness -> Game (coverage tracking per named scope)
+```
+
+`VideoAsset` stores detailed codec and quality metadata (resolution, bitrate, FPS, SHA-256 checksums). `GameCompleteness` tracks coverage status per game within named scopes (e.g., `"NFL_ALL"`, `"STEELERS_ALL"`).
+
+### Scrapers
+
+Data ingestion is handled by a hierarchy of scrapers in `archive/scrapers/`:
+
+- **`BaseScraper`** — HTTP fetching with BeautifulSoup and optional Playwright browser support
+- **`NFLScraper`** — fetches NFL team and game data via the Griddy SDK; creates teams, venues, and affiliations
+- **`NFLDataIngestor`** — transforms Griddy SDK game data into Django model instances (games, drives, plays, boxscores, standings, replays)
+- **`SportsRefCFBScraper`** — scrapes NCAA FBS schedules and team data from sports-reference.com
+- **`WikipediaCFBScraper`** — scrapes college football data from Wikipedia
+
+## Documentation
+
+Documentation is built with [Zensical](https://zensical.org/) (Material theme) and [mkdocstrings](https://mkdocstrings.github.io/) for API reference generation.
+
+```bash
+# Install doc dependencies
+uv sync --group docs
+
+# Serve docs locally
+uv run zensical serve
+```
+
+## Development
+
+```bash
+# Install all dependencies
+uv sync --all-groups
+
+# Run tests
+uv run pytest
+
+# Lint and format
+uv run ruff check --fix .
+uv run ruff format .
+```
+
+## License
+
+Copyright 2026 Thistle Grow Software. All rights reserved.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,161 @@
+# Architecture
+
+GAM is a single Django app (`archive`) with a two-domain data model and a scraper-based
+data ingestion pipeline.
+
+## Data Model
+
+### Catalog Domain
+
+The catalog domain models the football world — leagues, teams, games, and their relationships.
+
+#### League Structure
+
+```
+League -> Season -> Game
+```
+
+A **League** represents a competition (e.g., NFL, NCAA FBS) at a specific level of play
+(High School, College, Professional). Each league contains **Seasons** identified by year,
+and each season contains **Games**.
+
+#### Teams and Franchises
+
+```
+Franchise -> Team (one-to-many, era-based)
+Team -> TeamAffiliation -> OrgUnit
+```
+
+A **Franchise** groups era-specific **Team** records. For example, the "Cleveland Browns"
+franchise might have team records for different eras separated by a hiatus. Each team
+record has `era_start_date` and `era_end_date` fields.
+
+**OrgUnit** models hierarchical organizational units — conferences, divisions, regions,
+classifications, and league tiers. OrgUnits can nest via a self-referential `parent`
+foreign key (e.g., AFC -> AFC North).
+
+**TeamAffiliation** links a team to an OrgUnit with temporal scoping — either by `Season`
+or by explicit date range (`start_date`/`end_date`). This supports tracking conference
+realignment over time.
+
+#### Venues
+
+```
+Venue <- TeamVenueOccupancy -> Team
+```
+
+**Venue** stores stadium information. **TeamVenueOccupancy** tracks which team plays at
+which venue over time, supporting stadium moves and shared venues.
+
+#### Games
+
+A **Game** links two teams (home and away) within a season, with support for:
+
+- Game classification (`GameType`: regular season, postseason, bowl, playoff, etc.)
+- Neutral site games
+- AP Poll rankings at game time
+- Broadcast channel and overtime tracking
+
+Each game can have detailed sub-records:
+
+- **QuarterScore** — score by period (quarters and overtime)
+- **Drive** — drive-level data (start/end position, plays, yards, time of possession)
+- **Play** — individual play data (down, distance, description, scoring, red zone, NGS data)
+- **PlayStat** — per-player stats on individual plays
+- **Player boxscores** — game-level stats by category (passing, rushing, receiving, tackles, fumbles, field goals, extra points, kicking, punting, returns)
+- **TeamStandingsSnapshot** — team standings at a specific week
+- **GameReplay** — video replay/clip metadata
+
+### Holdings Domain
+
+The holdings domain tracks video assets you own and their provenance.
+
+#### Asset Pipeline
+
+```
+Source -> Acquisition -> VideoAsset -> Game
+```
+
+A **Source** represents where content comes from (`SourceType`: streaming, YouTube, physical
+media, DVR capture, file trade). An **Acquisition** records a purchase or transfer from a
+source, including cost, rights, and proof of purchase.
+
+A **VideoAsset** is a single file representing one cut of one game. It stores detailed
+technical metadata:
+
+- Container format, video/audio codecs
+- Resolution, frame rate, bitrate
+- File size and SHA-256 checksum
+- Quality tier (A through D) with notes
+- Asset type (full broadcast, condensed, coaches film, All-22, highlights, radio)
+
+The `is_preferred` flag marks the best available asset per game (enforced as unique).
+
+#### Tagging and Completeness
+
+**Tag** and **AssetTag** provide flexible categorization of video assets.
+
+**GameCompleteness** tracks coverage status per game within named scopes (e.g.,
+`"NFL_ALL"`, `"STEELERS_ALL"`, `"UGA_ALL"`). Status values include missing, partial,
+complete, and complete-needs-upgrade, along with flags for which asset types are available.
+
+### Base Model
+
+All models inherit from **GamBaseModel**, which provides two JSONFields:
+
+- `bonus_data` — arbitrary supplemental data
+- `external_ids` — league-specific identifiers (e.g., NFL.com smartId, teamId)
+
+## Scrapers
+
+Data ingestion uses a hierarchy of scrapers in `archive/scrapers/`:
+
+### BaseScraper
+
+Provides HTTP fetching with BeautifulSoup parsing and optional Playwright-based browser
+rendering for JavaScript-heavy pages.
+
+### NFLScraper
+
+Fetches NFL team and game data using the [Griddy SDK](https://github.com/Thistle-Grow-Software/griddy-sdk-python).
+Handles:
+
+- Team creation with division affiliations
+- Venue processing and team-venue occupancy
+- Weekly game data gathering (drive charts, replays, standings, tagged videos)
+
+### NFLDataIngestor
+
+Transforms Griddy SDK data into Django model instances. Resolves teams by abbreviation,
+smartId, or NFL ID, then creates:
+
+- Game records with venue and score data
+- Standings snapshots
+- Player boxscores (all categories)
+- Drive charts and play-by-play data
+- Game replay metadata
+
+### SportsRefCFBScraper
+
+Scrapes NCAA FBS data from sports-reference.com:
+
+- Team lists with conference affiliations
+- Season schedules with game details
+- Tracks FCS schools encountered but not in the database
+
+### WikipediaCFBScraper
+
+Supplements college football data from Wikipedia (currently a stub implementation).
+
+## Enumerations
+
+Models use Django `TextChoices` extensively:
+
+| Enum | Values |
+|---|---|
+| `Level` | HS, COLLEGE, PRO, OTHER |
+| `GameType` | REG, CONF, POST, BOWL, PLAYOFF, EXHIB, OTHER |
+| `AssetType` | FULL, CONDENSED, COACHES, ALL22, HIGHLIGHTS, RADIO, OTHER |
+| `SourceType` | STREAMING, YOUTUBE, PHYSICAL, DVR, FILE_TRADE, OTHER |
+| `QualityTier` | A (Best), B (Very Good), C (Good), D (Filler) |
+| `Rights` | PERSONAL_ONLY, SHAREABLE, UNKNOWN |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,176 @@
+# Management Commands
+
+GAM provides several Django management commands for data ingestion and exploration.
+Commands built with [django-click](https://github.com/GaretJax/django-click) use a
+subcommand pattern; standard Django commands use positional arguments.
+
+## scrape_games
+
+The primary data ingestion command. Built with django-click as a command group with
+two subcommands: `nfl` and `cfb`.
+
+### scrape_games nfl
+
+Scrape NFL game data from NFL.com using the Griddy SDK.
+
+```bash
+uv run manage.py scrape_games nfl --season 2024 --min-week 1 --max-week 18 --store-db
+```
+
+**Options:**
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+| `--season` | int | Yes | NFL season year |
+| `--week` | int | No | Specific week number |
+| `--season-type` | REG/POST | No | Season type (default: `REG`) |
+| `--min-week` | int | No | Minimum week number (for range scraping) |
+| `--max-week` | int | No | Maximum week number (for range scraping) |
+| `--login-email` | str | No | NFL.com email for authentication |
+| `--login-password` | str | No | NFL.com password for authentication |
+| `--creds` | str | No | Path to credentials JSON file |
+| `--headless` | flag | No | Use headless browser for login |
+| `--output-file` | str | No | Path to write JSON output |
+| `--store-db` | flag | No | Store data in the database (default: dry run) |
+
+**Behavior:**
+
+- Iterates over the week range (`min-week` to `max-week`)
+- For each week, fetches game details including drive charts, replays, standings, and tagged videos
+- With `--store-db`: creates/updates `Game`, boxscore, drive, play, standings, and replay records
+- Without `--store-db`: writes raw JSON to fixture files
+- With `--output-file`: also writes JSON output alongside database storage
+
+**Prerequisites:**
+
+- `League` and `Season` records must exist in the database for the target season
+- NFL.com authentication credentials (via options or environment variables)
+
+### scrape_games cfb
+
+Scrape NCAA FBS game data from sports-reference.com.
+
+```bash
+uv run manage.py scrape_games cfb 2024 --store-db
+```
+
+**Arguments:**
+
+| Argument | Type | Description |
+|---|---|---|
+| `season` | int | Season year |
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `--output-file` | str | Path to write scraped game data as JSON |
+| `--store-db` | flag | Store data in the database (default: dry run) |
+
+**Behavior:**
+
+- Fetches the season schedule from sports-reference.com
+- Extracts game rows and parses team/score/date information
+- With `--store-db`: creates `Game` records in the database
+- Without `--store-db`: parses and validates games without persisting (dry run)
+- Reports FCS schools encountered that are not in the database
+- Reports games that failed to process
+
+## scrapegames
+
+Legacy Django management command for loading previously scraped game data from JSON files.
+
+```bash
+uv run manage.py scrapegames "NCAA - FBS" 2024 --data_path games.json
+```
+
+**Arguments:**
+
+| Argument | Type | Description |
+|---|---|---|
+| `league` | str | League name (e.g., `"NCAA - FBS"`) |
+| `season` | int | Season year |
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `--week` | int | Specific week number |
+| `--data_path` | str | Path to a JSON file containing scraped game data |
+
+**Behavior:**
+
+- Loads game data from the specified JSON file
+- Currently supports `"NCAA - FBS"` (uses `SportsRefCFBScraper.load_games_from_scraped_json`)
+- NFL support is stubbed but not yet implemented
+
+## scrapenflteams
+
+Load NFL team data from a JSON file into the database.
+
+```bash
+uv run manage.py scrapenflteams nfl_teams.json
+```
+
+**Arguments:**
+
+| Argument | Type | Description |
+|---|---|---|
+| `data_path` | str | Path to a JSON file containing NFL team data |
+
+**Behavior:**
+
+- Reads the JSON file containing NFL team data (as returned by the Griddy SDK)
+- Skips conference-level entries (AFC, NFC) and teams that already exist
+- For each new team, creates `Team`, `Venue`, `TeamVenueOccupancy`, and division `TeamAffiliation` records via `NFLScraper.create_db_object()`
+
+## sandbox
+
+Development and exploration commands for comparing NFL API data structures. Built with
+django-click as a command group.
+
+### sandbox comparison
+
+Compare schema differences between old and modern NFL API endpoints.
+
+```bash
+uv run manage.py sandbox comparison --fetch --creds-file creds.json
+```
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `--fetch` | flag | Pull live data from NFL.com (otherwise reads cached JSON) |
+| `--email` | str | NFL.com email |
+| `--password` | str | NFL.com password |
+| `--creds-file` | str | Path to credentials JSON file |
+
+**Behavior:**
+
+- Compares `weekly_game_details` schema between a 2015 and 2016 game
+- Generates `all_reg_keys.json`, `combined_pro_info.json`, and `missing_keys.json`
+- Without `--fetch`: reads previously cached JSON files and converts keys to snake_case
+
+### sandbox boxscore_comparison
+
+Compare historic vs. modern boxscore data structures.
+
+```bash
+uv run manage.py sandbox boxscore_comparison --fetch --creds-file creds.json
+```
+
+**Options:**
+
+| Option | Type | Description |
+|---|---|---|
+| `--fetch` | flag | Pull live data from NFL.com |
+| `--email` | str | NFL.com email |
+| `--password` | str | NFL.com password |
+| `--creds-file` | str | Path to credentials JSON file |
+
+**Behavior:**
+
+- Compares historic game details, live stats, and historical stats endpoints
+- Compares against modern pro API endpoints (boxscore, game center, playlist)
+- Generates `historic_game_info.json` and `pro_game_info.json`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,84 @@
+# Getting Started
+
+## Prerequisites
+
+- **Python 3.14+**
+- **PostgreSQL** — GAM uses PostgreSQL as its database backend
+- **[uv](https://docs.astral.sh/uv/)** — for dependency management
+- **AWS CodeArtifact access** — the `griddy` SDK is hosted on a private CodeArtifact registry
+
+## Installation
+
+Clone the repository and install dependencies:
+
+```bash
+git clone https://github.com/Thistle-Grow-Software/all-things-griddy.git
+cd all-things-griddy/griddy-archive-manager
+uv sync
+```
+
+## Configuration
+
+GAM reads its database connection and authentication credentials from environment variables.
+
+### Required Variables
+
+| Variable | Description |
+|---|---|
+| `PG_HOST` | PostgreSQL host (e.g., `localhost`) |
+| `PG_PORT` | PostgreSQL port (e.g., `5432`) |
+| `PG_DB_NAME` | PostgreSQL database name (e.g., `griddy`) |
+| `PG_USER` | PostgreSQL user |
+| `PG_PASSWORD` | PostgreSQL password |
+
+### Optional Variables
+
+| Variable | Description |
+|---|---|
+| `GRIDDY_NFL_EMAIL` | NFL.com email for authenticated API access |
+| `GRIDDY_NFL_PASSWORD` | NFL.com password for authenticated API access |
+| `MEDIA_ROOT` | Directory for uploaded media files (team logos, etc.) |
+| `AWS_CODEARTIFACT_TOKEN` | Authentication token for AWS CodeArtifact |
+
+## Database Setup
+
+Create the PostgreSQL database and apply migrations:
+
+```bash
+createdb griddy
+uv run manage.py migrate
+```
+
+## Create a Superuser
+
+The admin interface requires authentication:
+
+```bash
+uv run manage.py createsuperuser
+```
+
+## Run the Development Server
+
+```bash
+uv run manage.py runserver
+```
+
+The Django admin interface is available at [http://localhost:8000/admin/](http://localhost:8000/admin/).
+
+## Shell Aliases
+
+If you work in this project frequently, the following bash aliases (defined in the project's
+`.bashrc` conventions) can speed up common operations:
+
+| Alias | Description |
+|---|---|
+| `gam` | Navigate to the project directory, set env vars, and initialize CodeArtifact auth |
+| `uvrm` | Shortcut for `uv run manage.py` (e.g., `uvrm migrate`) |
+| `tgf-format` | Run `ruff check --fix` and `ruff format` on the current directory |
+| `artifact-token` | Initialize AWS CodeArtifact authentication |
+
+## Next Steps
+
+- Learn about the [Architecture](architecture.md) and data model
+- Explore the [Management Commands](commands.md) for data ingestion
+- Browse the [API Reference](reference/index.md) for model documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,40 @@
+# Griddy Archive Manager
+
+Griddy Archive Manager (GAM) is a Django 6.0+ application for cataloging and managing
+football game video archives across multiple levels of play — High School, College,
+and Professional.
+
+## What It Does
+
+GAM organizes football data into two domains:
+
+**Catalog** — tracks what exists in the football world:
+
+- Leagues, seasons, and games
+- Teams with franchise history and era tracking
+- Organizational hierarchies (conferences, divisions) with realignment support
+- Venues and team occupancy history
+- Game-level detail: drives, plays, player boxscores, standings snapshots
+
+**Holdings** — tracks what you own:
+
+- Video assets with codec-level quality metadata
+- Acquisition records (source, cost, rights)
+- Coverage completeness tracking per game and scope
+- Flexible tagging system
+
+## Data Ingestion
+
+GAM populates its catalog through a hierarchy of scrapers:
+
+- **NFL.com** — game data, drive charts, play-by-play, boxscores, replays, and standings via the [Griddy SDK](https://github.com/Thistle-Grow-Software/griddy-sdk-python)
+- **Sports-Reference** — NCAA FBS schedules and team data
+- **Wikipedia** — supplemental college football data
+
+## Getting Started
+
+See the [Getting Started](getting-started.md) guide for installation and setup instructions.
+
+## Architecture
+
+See the [Architecture](architecture.md) page for a detailed description of the data model and scraper hierarchy.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,6 @@
+# API Reference
+
+Auto-generated reference documentation for the `archive` app.
+
+- [Models](models.md) — Django models for the Catalog and Holdings domains
+- [Scrapers](scrapers.md) — Data ingestion scrapers

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -1,0 +1,87 @@
+# Models
+
+## Enumerations
+
+::: archive.models.Level
+
+::: archive.models.GameType
+
+::: archive.models.AssetType
+
+::: archive.models.Rights
+
+::: archive.models.QualityTier
+
+::: archive.models.SourceType
+
+## Base
+
+::: archive.models.GamBaseModel
+
+## Catalog Domain
+
+::: archive.models.League
+
+::: archive.models.Season
+
+::: archive.models.Franchise
+
+::: archive.models.Team
+
+::: archive.models.OrgUnit
+
+::: archive.models.TeamAffiliation
+
+::: archive.models.Venue
+
+::: archive.models.TeamVenueOccupancy
+
+::: archive.models.Game
+
+::: archive.models.QuarterScore
+
+::: archive.models.TeamStandingsSnapshot
+
+::: archive.models.Drive
+
+::: archive.models.Play
+
+::: archive.models.PlayStat
+
+## Player Boxscores
+
+::: archive.models.PassingBoxscore
+
+::: archive.models.RushingBoxscore
+
+::: archive.models.ReceivingBoxscore
+
+::: archive.models.TacklesBoxscore
+
+::: archive.models.FumblesBoxscore
+
+::: archive.models.FieldGoalsBoxscore
+
+::: archive.models.ExtraPointsBoxscore
+
+::: archive.models.KickingBoxscore
+
+::: archive.models.PuntingBoxscore
+
+::: archive.models.ReturnBoxscore
+
+::: archive.models.GameReplay
+
+## Holdings Domain
+
+::: archive.models.Source
+
+::: archive.models.Acquisition
+
+::: archive.models.VideoAsset
+
+::: archive.models.Tag
+
+::: archive.models.AssetTag
+
+::: archive.models.GameCompleteness

--- a/docs/reference/scrapers.md
+++ b/docs/reference/scrapers.md
@@ -1,0 +1,11 @@
+# Scrapers
+
+::: archive.scrapers.BaseScraper
+
+::: archive.scrapers.NFLScraper
+
+::: archive.scrapers.NFLDataIngestor
+
+::: archive.scrapers.SportsRefCFBScraper
+
+::: archive.scrapers.WikipediaCFBScraper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ dev = [
     "django-extensions>=4.1",
     "ipython>=9.10.0",
 ]
+docs = [
+    "zensical>=0.0.28",
+    "mkdocstrings[python]>=0.29.0",
+]
 
 [[tool.uv.index]]
 name = "private-registry"

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,8 +1,7 @@
 """Tests to ensure documentation infrastructure is correctly configured."""
 
-from pathlib import Path
-
 import tomllib
+from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 DOCS_DIR = PROJECT_ROOT / "docs"
@@ -25,7 +24,9 @@ def test_zensical_toml_has_mkdocstrings():
     """zensical.toml must configure mkdocstrings plugin."""
     config = tomllib.loads(ZENSICAL_TOML.read_text())
     plugins = config["project"].get("plugins", {})
-    assert "mkdocstrings" in plugins, "mkdocstrings plugin not configured in zensical.toml"
+    assert "mkdocstrings" in plugins, (
+        "mkdocstrings plugin not configured in zensical.toml"
+    )
 
 
 def test_zensical_toml_has_material_theme():
@@ -72,7 +73,9 @@ def test_nav_pages_match_docs_directory():
         return paths
 
     for path in extract_paths(nav):
-        assert (DOCS_DIR / path).exists(), f"Nav references docs/{path} but file not found"
+        assert (DOCS_DIR / path).exists(), (
+            f"Nav references docs/{path} but file not found"
+        )
 
 
 def test_readme_is_not_empty():
@@ -121,9 +124,7 @@ def test_models_reference_page_has_key_models():
         "VideoAsset",
     ]
     for model in required_models:
-        assert f"archive.models.{model}" in content, (
-            f"Models reference missing {model}"
-        )
+        assert f"archive.models.{model}" in content, f"Models reference missing {model}"
 
 
 def test_commands_page_documents_all_commands():

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -1,0 +1,135 @@
+"""Tests to ensure documentation infrastructure is correctly configured."""
+
+from pathlib import Path
+
+import tomllib
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DOCS_DIR = PROJECT_ROOT / "docs"
+ZENSICAL_TOML = PROJECT_ROOT / "zensical.toml"
+PYPROJECT_PATH = PROJECT_ROOT / "pyproject.toml"
+
+
+def test_zensical_toml_exists():
+    """zensical.toml must exist in the project root."""
+    assert ZENSICAL_TOML.exists(), "zensical.toml not found in project root"
+
+
+def test_zensical_toml_is_valid():
+    """zensical.toml must be valid TOML."""
+    config = tomllib.loads(ZENSICAL_TOML.read_text())
+    assert "project" in config, "zensical.toml missing [project] section"
+
+
+def test_zensical_toml_has_mkdocstrings():
+    """zensical.toml must configure mkdocstrings plugin."""
+    config = tomllib.loads(ZENSICAL_TOML.read_text())
+    plugins = config["project"].get("plugins", {})
+    assert "mkdocstrings" in plugins, "mkdocstrings plugin not configured in zensical.toml"
+
+
+def test_zensical_toml_has_material_theme():
+    """zensical.toml must configure a theme with palette (Material theme)."""
+    config = tomllib.loads(ZENSICAL_TOML.read_text())
+    theme = config["project"].get("theme", {})
+    assert "palette" in theme, "Theme palette not configured in zensical.toml"
+
+
+def test_docs_directory_exists():
+    """A docs/ directory must exist."""
+    assert DOCS_DIR.is_dir(), "docs/ directory not found"
+
+
+def test_required_doc_pages_exist():
+    """All nav-referenced doc pages must exist."""
+    required_pages = [
+        "index.md",
+        "getting-started.md",
+        "architecture.md",
+        "commands.md",
+        "reference/index.md",
+        "reference/models.md",
+        "reference/scrapers.md",
+    ]
+    for page in required_pages:
+        assert (DOCS_DIR / page).exists(), f"docs/{page} not found"
+
+
+def test_nav_pages_match_docs_directory():
+    """All pages listed in zensical.toml nav must exist in docs/."""
+    config = tomllib.loads(ZENSICAL_TOML.read_text())
+    nav = config["project"].get("nav", [])
+
+    def extract_paths(nav_items):
+        paths = []
+        for item in nav_items:
+            for value in item.values():
+                if isinstance(value, str):
+                    if value:
+                        paths.append(value)
+                elif isinstance(value, list):
+                    paths.extend(extract_paths(value))
+        return paths
+
+    for path in extract_paths(nav):
+        assert (DOCS_DIR / path).exists(), f"Nav references docs/{path} but file not found"
+
+
+def test_readme_is_not_empty():
+    """README.md must contain substantive content."""
+    readme = (PROJECT_ROOT / "README.md").read_text()
+    assert len(readme) > 100, "README.md appears to be empty or trivially short"
+    assert "Griddy Archive Manager" in readme, "README.md missing project name"
+
+
+def test_readme_has_setup_instructions():
+    """README.md must contain installation/setup instructions."""
+    readme = (PROJECT_ROOT / "README.md").read_text()
+    assert "uv sync" in readme, "README.md missing dependency install instructions"
+    assert "migrate" in readme, "README.md missing migration instructions"
+
+
+def test_readme_describes_both_domains():
+    """README.md must cover both the Catalog and Holdings domains."""
+    readme = (PROJECT_ROOT / "README.md").read_text()
+    assert "Catalog" in readme, "README.md missing Catalog domain description"
+    assert "Holdings" in readme, "README.md missing Holdings domain description"
+
+
+def test_doc_dependencies_declared():
+    """Doc dependencies must be declared in pyproject.toml."""
+    config = tomllib.loads(PYPROJECT_PATH.read_text())
+    groups = config.get("dependency-groups", {})
+    assert "docs" in groups, "docs dependency group not found in pyproject.toml"
+    docs_deps = groups["docs"]
+    dep_names = [d.split(">")[0].split("[")[0].strip('"') for d in docs_deps]
+    assert "zensical" in dep_names, "zensical not in docs dependencies"
+    assert "mkdocstrings" in dep_names, "mkdocstrings not in docs dependencies"
+
+
+def test_models_reference_page_has_key_models():
+    """The models reference page must reference all key models."""
+    content = (DOCS_DIR / "reference" / "models.md").read_text()
+    required_models = [
+        "League",
+        "Season",
+        "Game",
+        "Team",
+        "Venue",
+        "Source",
+        "Acquisition",
+        "VideoAsset",
+    ]
+    for model in required_models:
+        assert f"archive.models.{model}" in content, (
+            f"Models reference missing {model}"
+        )
+
+
+def test_commands_page_documents_all_commands():
+    """The commands page must document all management commands."""
+    content = (DOCS_DIR / "commands.md").read_text()
+    assert "scrape_games" in content, "commands.md missing scrape_games"
+    assert "scrapegames" in content, "commands.md missing scrapegames"
+    assert "scrapenflteams" in content, "commands.md missing scrapenflteams"
+    assert "sandbox" in content, "commands.md missing sandbox"

--- a/uv.lock
+++ b/uv.lock
@@ -158,6 +158,15 @@ wheels = [
 ]
 
 [[package]]
+name = "deepmerge"
+version = "2.0"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/deepmerge/2.0/deepmerge-2.0.tar.gz", hash = "sha256:5c3d86081fbebd04dd5de03626a0607b809a98fb6ccba5770b62466fe940ff20" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/deepmerge/2.0/deepmerge-2.0-py3-none-any.whl", hash = "sha256:6de9ce507115cff0bed95ff0ce9ecc31088ef50cbdf09bc90a09349a318b3d00" },
+]
+
+[[package]]
 name = "django"
 version = "6.0.1"
 source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
@@ -246,6 +255,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/ghp-import/2.1.0/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/ghp-import/2.1.0/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619" },
+]
+
+[[package]]
 name = "griddy"
 version = "0.45.0"
 source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
@@ -287,6 +308,10 @@ dev = [
     { name = "pytest-django" },
     { name = "ruff" },
 ]
+docs = [
+    { name = "mkdocstrings", extra = ["python"] },
+    { name = "zensical" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -309,6 +334,19 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-django", specifier = ">=4.9" },
     { name = "ruff", specifier = ">=0.11" },
+]
+docs = [
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0" },
+    { name = "zensical", specifier = ">=0.0.28" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.1"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/griffelib/2.0.1/griffelib-2.0.1.tar.gz", hash = "sha256:59f39eabb4c777483a3823e39e8f9e03e69df271a7e49aee64e91a8cfa91bdf5" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/griffelib/2.0.1/griffelib-2.0.1-py3-none-any.whl", hash = "sha256:b769eed581c0e857d362fc8fcd8e57ecd2330c124b6104ac8b4c1c86d76970aa" },
 ]
 
 [[package]]
@@ -412,6 +450,57 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/jinja2/3.1.6/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/jinja2/3.1.6/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67" },
+]
+
+[[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markdown/3.10.2/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markdown/3.10.2/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/markupsafe/3.0.3/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa" },
+]
+
+[[package]]
 name = "matplotlib-inline"
 version = "0.2.1"
 source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
@@ -421,6 +510,103 @@ dependencies = [
 sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/matplotlib-inline/0.2.1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe" }
 wheels = [
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/matplotlib-inline/0.2.1/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mergedeep/1.3.4/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mergedeep/1.3.4/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mkdocs/1.6.1/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mkdocs/1.6.1/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e" },
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.4.4"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mkdocs-autorefs/1.4.4/mkdocs_autorefs-1.4.4.tar.gz", hash = "sha256:d54a284f27a7346b9c38f1f852177940c222da508e66edc816a0fa55fc6da197" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mkdocs-autorefs/1.4.4/mkdocs_autorefs-1.4.4-py3-none-any.whl", hash = "sha256:834ef5408d827071ad1bc69e0f39704fa34c7fc05bc8e1c72b227dfdc5c76089" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mkdocs-get-deps/0.2.2/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mkdocs-get-deps/0.2.2/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.3"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mkdocstrings/1.0.3/mkdocstrings-1.0.3.tar.gz", hash = "sha256:ab670f55040722b49bb45865b2e93b824450fb4aef638b00d7acb493a9020434" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mkdocstrings/1.0.3/mkdocstrings-1.0.3-py3-none-any.whl", hash = "sha256:0d66d18430c2201dc7fe85134277382baaa15e6b30979f3f3bdbabd6dbdb6046" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.3"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mkdocstrings-python/2.0.3/mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/mkdocstrings-python/2.0.3/mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12" },
 ]
 
 [[package]]
@@ -439,6 +625,15 @@ source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-
 sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/parso/0.8.5/parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a" }
 wheels = [
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/parso/0.8.5/parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pathspec/1.0.4/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pathspec/1.0.4/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723" },
 ]
 
 [[package]]
@@ -484,6 +679,15 @@ wheels = [
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pillow/12.1.0/pillow-12.1.0-cp314-cp314t-win32.whl", hash = "sha256:b17fbdbe01c196e7e159aacb889e091f28e61020a8abeac07b68079b6e626988" },
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pillow/12.1.0/pillow-12.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27b9baecb428899db6c0de572d6d305cfaf38ca1596b5c0542a5182e3e74e8c6" },
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pillow/12.1.0/pillow-12.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f61333d817698bdcdd0f9d7793e365ac3d2a21c1f1eb02b32ad6aefb8d8ea831" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/platformdirs/4.9.4/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/platformdirs/4.9.4/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868" },
 ]
 
 [[package]]
@@ -615,6 +819,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pymdown-extensions/10.21/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pymdown-extensions/10.21/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
@@ -701,6 +918,18 @@ wheels = [
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pyyaml/6.0.3/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65" },
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pyyaml/6.0.3/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9" },
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pyyaml/6.0.3/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pyyaml-env-tag/1.1/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pyyaml-env-tag/1.1/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04" },
 ]
 
 [[package]]
@@ -842,10 +1071,56 @@ wheels = [
 ]
 
 [[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/watchdog/6.0.0/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f" },
+]
+
+[[package]]
 name = "wcwidth"
 version = "0.5.3"
 source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
 sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/wcwidth/0.5.3/wcwidth-0.5.3.tar.gz", hash = "sha256:53123b7af053c74e9fe2e92ac810301f6139e64379031f7124574212fb3b4091" }
 wheels = [
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/wcwidth/0.5.3/wcwidth-0.5.3-py3-none-any.whl", hash = "sha256:d584eff31cd4753e1e5ff6c12e1edfdb324c995713f75d26c29807bb84bf649e" },
+]
+
+[[package]]
+name = "zensical"
+version = "0.0.29"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "click" },
+    { name = "deepmerge" },
+    { name = "markdown" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29.tar.gz", hash = "sha256:0d6282be7cb551e12d5806badf5e94c54a5e2f2cf07057a3e36d1eaf97c33ada" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:20ae0709ea14fce25ab33d0a82acdaf454a7a2e232a9ee20c019942205174476" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:599af3ba66fcd0146d7019f3493ed3c316051fae6c4d5599bc59f3a8f4b8a6f0" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eea7e48a00a71c0586e875079b5f83a070c33a147e52ad4383e4b63ab524332b" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:59a57db35542e98d2896b833de07d199320f8ada3b4e7ddccb7fe892292d8b74" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d42c2b2a96a80cf64c98ba7242f59ef95109914bd4c9499d7ebc12544663852c" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b2fca39c5f6b1782c77cf6591cf346357cabee85ebdb956c5ddc0fd5169f3d9" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:dfc23a74ef672aa51088c080286319da1dc0b989cd5051e9e5e6d7d4abbc2fc1" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:c9336d4e4b232e3c9a70e30258e916dd7e60c0a2a08c8690065e60350c302028" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:30661148f0681199f3b598cbeb1d54f5cba773e54ae840bac639250d85907b84" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6a566ac1fd4bfac5d711a7bd1ae06666712127c2718daa5083c7bf3f107e8578" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-win32.whl", hash = "sha256:a231a3a02a3851741dc4d2de8910b5c39fe81e55bf026d8edf4d803e91a922fb" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/zensical/0.0.29/zensical-0.0.29-cp310-abi3-win_amd64.whl", hash = "sha256:7145c5504380a344b8cd4586da815cdde77ef4a42319fa4f35e78250f01985af" },
 ]

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,91 @@
+[project]
+
+site_name = "Griddy Archive Manager"
+site_description = "A Django application for cataloging and managing football game video archives."
+site_author = "John Griebel"
+site_url = "https://docs.thistlegrow.com/"
+repo_url = "https://github.com/Thistle-Grow-Software/all-things-griddy"
+edit_uri = "edit/master/griddy-archive-manager/docs/"
+
+copyright = """
+Copyright &copy; 2026 The authors
+"""
+
+nav = [
+    { "Home" = "index.md" },
+    { "Getting Started" = "getting-started.md" },
+    { "Architecture" = "architecture.md" },
+    { "Management Commands" = "commands.md" },
+    { "API Reference" = [
+        { "" = "reference/index.md" },
+        { "Models" = "reference/models.md" },
+        { "Scrapers" = "reference/scrapers.md" },
+    ]},
+]
+
+[project.theme]
+
+language = "en"
+
+features = [
+    "announce.dismiss",
+    "content.action.edit",
+    "content.action.view",
+    "content.code.annotate",
+    "content.code.copy",
+    "content.code.select",
+    "content.footnote.tooltips",
+    "content.tabs.link",
+    "content.tooltips",
+    "navigation.footer",
+    "navigation.indexes",
+    "navigation.instant",
+    "navigation.instant.prefetch",
+    "navigation.path",
+    "navigation.sections",
+    "navigation.top",
+    "navigation.tracking",
+    "search.highlight",
+]
+
+[[project.theme.palette]]
+scheme = "default"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+scheme = "slate"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"
+
+[project.extra.version]
+provider = "mike"
+default = "latest"
+
+[[project.extra.social]]
+icon = "fontawesome/brands/github"
+link = "https://github.com/Thistle-Grow-Software/all-things-griddy"
+
+# ----------------------------------------------------------------------------
+# Plugin configuration
+# ----------------------------------------------------------------------------
+
+# mkdocstrings: Auto-generate API reference from Python docstrings
+[project.plugins.mkdocstrings]
+[project.plugins.mkdocstrings.handlers.python]
+paths = ["."]
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+docstring_options = { ignore_init_summary = true }
+merge_init_into_class = true
+show_source = true
+show_root_heading = true
+show_root_full_path = false
+show_symbol_type_heading = true
+show_symbol_type_toc = true
+members_order = "source"
+signature_crossrefs = true
+separate_signature = true
+unwrap_annotated = true
+filters = ["!^_"]
+heading_level = 1


### PR DESCRIPTION
## Summary

- Set up documentation infrastructure using Zensical (Material theme) and mkdocstrings for API reference generation
- Write README.md with project overview, installation/setup guide, and architecture description covering both the Catalog and Holdings data domains
- Create docs/ pages: home, getting started, architecture, management commands (scrape_games, scrapegames, scrapenflteams, sandbox), and API reference for models and scrapers
- Add `zensical` and `mkdocstrings[python]` to a new `docs` dependency group in pyproject.toml
- Add 13 tests validating documentation structure, configuration, and content

## Test plan

- [x] `uv run pytest` — all 100 tests pass (87 existing + 13 new)
- [x] `uv run zensical build` — builds all 7 pages without errors
- [x] `uv run zensical serve` — serves docs locally and renders all pages correctly
- [x] `uv run ruff check . && uv run ruff format .` — no lint or formatting issues

Closes #247