### PR TITLE
feat(GAM #288): wire API URL routing at /api/v1/

### DIFF
--- a/gam/urls.py
+++ b/gam/urls.py
@@ -15,8 +15,16 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
-from debug_toolbar.toolbar import debug_toolbar_urls
+from django.conf import settings
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
-urlpatterns = [path("admin/", admin.site.urls), *debug_toolbar_urls()]
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("api/v1/", include("archive.api.router")),
+]
+
+if "debug_toolbar" in settings.INSTALLED_APPS:
+    from debug_toolbar.toolbar import debug_toolbar_urls
+
+    urlpatterns += debug_toolbar_urls()

--- a/tests/test_api_url_routing.py
+++ b/tests/test_api_url_routing.py
@@ -1,0 +1,47 @@
+"""Tests to verify API URL routing meets TGF-288 acceptance criteria."""
+
+import pytest
+from django.test import Client
+from django.urls import resolve, reverse
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.mark.django_db
+def test_api_v1_url_resolves():
+    """The /api/v1/ URL must resolve to the DRF router root."""
+    match = resolve("/api/v1/")
+    assert match is not None
+
+
+@pytest.mark.django_db
+def test_api_v1_returns_200(client):
+    """GET /api/v1/ must return HTTP 200."""
+    response = client.get("/api/v1/", HTTP_ACCEPT="application/json")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_api_v1_returns_empty_router_response(client):
+    """The API root must return an empty object (no registered endpoints yet)."""
+    response = client.get("/api/v1/", HTTP_ACCEPT="application/json")
+    assert response.json() == {}
+
+
+@pytest.mark.django_db
+def test_api_v1_browsable_api_available(client):
+    """Requesting /api/v1/ with text/html should return the browsable API."""
+    response = client.get("/api/v1/", HTTP_ACCEPT="text/html")
+    assert response.status_code == 200
+    assert "text/html" in response["Content-Type"]
+
+
+@pytest.mark.django_db
+def test_api_v1_url_is_included_in_urlconf():
+    """The api/v1/ path must be present in the root URL configuration."""
+    # reverse on the DRF api-root should produce /api/v1/
+    url = reverse("api-root")
+    assert url == "/api/v1/"


### PR DESCRIPTION
## Summary

- Add `path("api/v1/", include("archive.api.router"))` to `gam/urls.py`
- Make `debug_toolbar` URL import conditional on `INSTALLED_APPS` to fix CI compatibility (where the toolbar is stripped by `settings_ci.py`)
- Add 5 tests verifying URL resolution, HTTP 200, empty router JSON response, browsable API HTML response, and `reverse("api-root")` resolution

## Test plan

- [x] All 5 new API URL routing tests pass
- [x] Full test suite (130 tests) passes with no regressions
- [x] `manage.py check` reports no issues
- [x] `ruff check` and `ruff format` clean

Closes #288