### PR TITLE
feat(GAM #289): add League and Season serializers and viewsets

### DIFF
--- a/archive/api/router.py
+++ b/archive/api/router.py
@@ -1,5 +1,10 @@
 from rest_framework.routers import DefaultRouter
 
+from archive.api.viewsets.league import LeagueViewSet
+from archive.api.viewsets.season import SeasonViewSet
+
 router = DefaultRouter()
+router.register("leagues", LeagueViewSet, basename="league")
+router.register("seasons", SeasonViewSet, basename="season")
 
 urlpatterns = router.urls

--- a/archive/api/serializers/league.py
+++ b/archive/api/serializers/league.py
@@ -1,0 +1,48 @@
+from rest_framework import serializers
+
+from archive.models import League
+
+
+class LeagueListSerializer(serializers.ModelSerializer):
+    seasons_count = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = League
+        fields = ["id", "long_name", "short_name", "level", "seasons_count"]
+
+
+class LeagueDetailSerializer(serializers.ModelSerializer):
+    seasons = serializers.SerializerMethodField()
+
+    class Meta:
+        model = League
+        fields = [
+            "id",
+            "short_name",
+            "long_name",
+            "level",
+            "country",
+            "notes",
+            "bonus_data",
+            "external_ids",
+            "seasons",
+        ]
+
+    def get_seasons(self, obj):
+        from archive.api.serializers.season import SeasonListSerializer
+
+        return SeasonListSerializer(obj.seasons.all(), many=True).data
+
+
+class LeagueWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = League
+        fields = [
+            "short_name",
+            "long_name",
+            "level",
+            "country",
+            "notes",
+            "bonus_data",
+            "external_ids",
+        ]

--- a/archive/api/serializers/season.py
+++ b/archive/api/serializers/season.py
@@ -1,0 +1,42 @@
+from rest_framework import serializers
+
+from archive.models import Season
+
+
+class SeasonListSerializer(serializers.ModelSerializer):
+    league = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = Season
+        fields = ["id", "league", "year", "label", "start_date", "end_date"]
+
+
+class SeasonDetailSerializer(serializers.ModelSerializer):
+    league = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = Season
+        fields = [
+            "id",
+            "league",
+            "year",
+            "label",
+            "start_date",
+            "end_date",
+            "bonus_data",
+            "external_ids",
+        ]
+
+
+class SeasonWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Season
+        fields = [
+            "league",
+            "year",
+            "label",
+            "start_date",
+            "end_date",
+            "bonus_data",
+            "external_ids",
+        ]

--- a/archive/api/viewsets/league.py
+++ b/archive/api/viewsets/league.py
@@ -1,0 +1,41 @@
+from django.db.models import Count
+from rest_framework.mixins import (
+    CreateModelMixin,
+    ListModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+)
+from rest_framework.viewsets import GenericViewSet
+
+from archive.api.pagination import DefaultCursorPagination
+from archive.api.serializers.league import (
+    LeagueDetailSerializer,
+    LeagueListSerializer,
+    LeagueWriteSerializer,
+)
+from archive.models import League
+
+
+class LeagueViewSet(
+    ListModelMixin,
+    CreateModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+    GenericViewSet,
+):
+    pagination_class = DefaultCursorPagination
+
+    def get_queryset(self):
+        qs = League.objects.all()
+        if self.action == "list":
+            qs = qs.annotate(seasons_count=Count("seasons"))
+        elif self.action == "retrieve":
+            qs = qs.prefetch_related("seasons")
+        return qs
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return LeagueListSerializer
+        if self.action == "retrieve":
+            return LeagueDetailSerializer
+        return LeagueWriteSerializer

--- a/archive/api/viewsets/season.py
+++ b/archive/api/viewsets/season.py
@@ -1,0 +1,38 @@
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.mixins import (
+    CreateModelMixin,
+    ListModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+)
+from rest_framework.viewsets import GenericViewSet
+
+from archive.api.pagination import DefaultCursorPagination
+from archive.api.serializers.season import (
+    SeasonDetailSerializer,
+    SeasonListSerializer,
+    SeasonWriteSerializer,
+)
+from archive.models import Season
+
+
+class SeasonViewSet(
+    ListModelMixin,
+    CreateModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+    GenericViewSet,
+):
+    pagination_class = DefaultCursorPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["league", "year"]
+
+    def get_queryset(self):
+        return Season.objects.select_related("league").all()
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return SeasonListSerializer
+        if self.action == "retrieve":
+            return SeasonDetailSerializer
+        return SeasonWriteSerializer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "**/models.py" = ["RUF012"]
+"**/serializers/**" = ["RUF012"]       # DRF Meta.fields convention
+"**/viewsets/**" = ["RUF012"]          # DRF class-level list attributes
 "**/migrations/*.py" = ["ALL"]  # auto-generated, don't lint heavily
 "**/settings/*.py" = ["F405", "E501"]                 # wildcard imports common in settings
 "**/settings.py" = ["F405", "E501"]

--- a/tests/test_api_url_routing.py
+++ b/tests/test_api_url_routing.py
@@ -25,10 +25,11 @@ def test_api_v1_returns_200(client):
 
 
 @pytest.mark.django_db
-def test_api_v1_returns_empty_router_response(client):
-    """The API root must return an empty object (no registered endpoints yet)."""
+def test_api_v1_returns_router_response(client):
+    """The API root must return a JSON object listing registered endpoints."""
     response = client.get("/api/v1/", HTTP_ACCEPT="application/json")
-    assert response.json() == {}
+    data = response.json()
+    assert isinstance(data, dict)
 
 
 @pytest.mark.django_db

--- a/tests/test_league_season_api.py
+++ b/tests/test_league_season_api.py
@@ -1,0 +1,347 @@
+"""Tests for League and Season serializers and viewsets (TGF-289)."""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from archive.api.serializers.league import (
+    LeagueDetailSerializer,
+    LeagueListSerializer,
+    LeagueWriteSerializer,
+)
+from archive.api.serializers.season import (
+    SeasonDetailSerializer,
+    SeasonListSerializer,
+    SeasonWriteSerializer,
+)
+from archive.models import League, Season
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def nfl():
+    return League.objects.create(
+        short_name="NFL", long_name="National Football League", level="PRO"
+    )
+
+
+@pytest.fixture
+def ncaa():
+    return League.objects.create(
+        short_name="NCAA",
+        long_name="National Collegiate Athletic Association",
+        level="COLLEGE",
+    )
+
+
+@pytest.fixture
+def season_2024(nfl):
+    return Season.objects.create(league=nfl, year=2024, label="2024")
+
+
+@pytest.fixture
+def season_2025(nfl):
+    return Season.objects.create(league=nfl, year=2025, label="2025")
+
+
+# --- LeagueListSerializer ---
+
+
+@pytest.mark.django_db
+def test_league_list_serializer_fields(nfl, season_2024, season_2025):
+    """LeagueListSerializer includes id, long_name, short_name, level, seasons_count."""
+    from django.db.models import Count
+
+    qs = League.objects.annotate(seasons_count=Count("seasons"))
+    serializer = LeagueListSerializer(qs.get(pk=nfl.pk))
+    data = serializer.data
+    assert data["id"] == nfl.pk
+    assert data["long_name"] == "National Football League"
+    assert data["short_name"] == "NFL"
+    assert data["level"] == "PRO"
+    assert data["seasons_count"] == 2
+
+
+# --- LeagueDetailSerializer ---
+
+
+@pytest.mark.django_db
+def test_league_detail_serializer_includes_seasons(nfl, season_2024, season_2025):
+    """LeagueDetailSerializer includes all fields plus nested seasons list."""
+    league = League.objects.prefetch_related("seasons").get(pk=nfl.pk)
+    serializer = LeagueDetailSerializer(league)
+    data = serializer.data
+    assert data["id"] == nfl.pk
+    assert data["short_name"] == "NFL"
+    assert data["long_name"] == "National Football League"
+    assert data["level"] == "PRO"
+    assert data["country"] == "US"
+    assert "notes" in data
+    assert "bonus_data" in data
+    assert "external_ids" in data
+    assert len(data["seasons"]) == 2
+    season_years = {s["year"] for s in data["seasons"]}
+    assert season_years == {2024, 2025}
+
+
+# --- LeagueWriteSerializer ---
+
+
+@pytest.mark.django_db
+def test_league_write_serializer_creates():
+    """LeagueWriteSerializer can create a league with plain field values."""
+    serializer = LeagueWriteSerializer(
+        data={"short_name": "XFL", "long_name": "XFL", "level": "PRO"}
+    )
+    assert serializer.is_valid(), serializer.errors
+    league = serializer.save()
+    assert league.pk is not None
+    assert league.short_name == "XFL"
+
+
+# --- SeasonListSerializer ---
+
+
+@pytest.mark.django_db
+def test_season_list_serializer_fields(nfl, season_2024):
+    """SeasonListSerializer includes id, league, year, label, start_date, end_date."""
+    season = Season.objects.select_related("league").get(pk=season_2024.pk)
+    serializer = SeasonListSerializer(season)
+    data = serializer.data
+    assert data["id"] == season_2024.pk
+    assert data["league"] == nfl.pk
+    assert data["year"] == 2024
+    assert data["label"] == "2024"
+    assert "start_date" in data
+    assert "end_date" in data
+
+
+# --- SeasonDetailSerializer ---
+
+
+@pytest.mark.django_db
+def test_season_detail_serializer_all_fields(nfl, season_2024):
+    """SeasonDetailSerializer includes all fields."""
+    season = Season.objects.select_related("league").get(pk=season_2024.pk)
+    serializer = SeasonDetailSerializer(season)
+    data = serializer.data
+    assert data["id"] == season_2024.pk
+    assert data["league"] == nfl.pk
+    assert data["year"] == 2024
+    assert "bonus_data" in data
+    assert "external_ids" in data
+
+
+# --- SeasonWriteSerializer ---
+
+
+@pytest.mark.django_db
+def test_season_write_serializer_creates(nfl):
+    """SeasonWriteSerializer can create a season."""
+    serializer = SeasonWriteSerializer(
+        data={"league": nfl.pk, "year": 2023, "label": "2023"}
+    )
+    assert serializer.is_valid(), serializer.errors
+    season = serializer.save()
+    assert season.pk is not None
+    assert season.year == 2023
+
+
+# --- LeagueViewSet endpoints ---
+
+
+@pytest.mark.django_db
+def test_league_list_returns_200(client, nfl):
+    """GET /api/v1/leagues/ returns 200."""
+    response = client.get("/api/v1/leagues/", HTTP_ACCEPT="application/json")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_league_list_returns_paginated_results(client, nfl, ncaa):
+    """GET /api/v1/leagues/ returns paginated league list."""
+    response = client.get("/api/v1/leagues/", HTTP_ACCEPT="application/json")
+    data = response.json()
+    # CursorPagination wraps results in a dict with next/previous/results
+    assert "results" in data
+    assert len(data["results"]) == 2
+
+
+@pytest.mark.django_db
+def test_league_list_includes_seasons_count(client, nfl, season_2024, season_2025):
+    """League list results include seasons_count."""
+    response = client.get("/api/v1/leagues/", HTTP_ACCEPT="application/json")
+    results = response.json()["results"]
+    nfl_data = next(r for r in results if r["short_name"] == "NFL")
+    assert nfl_data["seasons_count"] == 2
+
+
+@pytest.mark.django_db
+def test_league_retrieve_returns_detail(client, nfl, season_2024):
+    """GET /api/v1/leagues/<id>/ returns detail with nested seasons."""
+    response = client.get(f"/api/v1/leagues/{nfl.pk}/", HTTP_ACCEPT="application/json")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["short_name"] == "NFL"
+    assert len(data["seasons"]) == 1
+    assert data["seasons"][0]["year"] == 2024
+
+
+@pytest.mark.django_db
+def test_league_create(client):
+    """POST /api/v1/leagues/ creates a new league."""
+    response = client.post(
+        "/api/v1/leagues/",
+        data={
+            "short_name": "USFL",
+            "long_name": "United States Football League",
+            "level": "PRO",
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    assert League.objects.filter(short_name="USFL").exists()
+
+
+@pytest.mark.django_db
+def test_league_update(client, nfl):
+    """PUT /api/v1/leagues/<id>/ updates the league."""
+    response = client.put(
+        f"/api/v1/leagues/{nfl.pk}/",
+        data={
+            "short_name": "NFL",
+            "long_name": "National Football League",
+            "level": "PRO",
+            "country": "US",
+            "notes": "Updated",
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    nfl.refresh_from_db()
+    assert nfl.notes == "Updated"
+
+
+@pytest.mark.django_db
+def test_league_delete_not_allowed(client, nfl):
+    """DELETE /api/v1/leagues/<id>/ is not supported."""
+    response = client.delete(f"/api/v1/leagues/{nfl.pk}/")
+    assert response.status_code == 405
+
+
+# --- SeasonViewSet endpoints ---
+
+
+@pytest.mark.django_db
+def test_season_list_returns_200(client, nfl, season_2024):
+    """GET /api/v1/seasons/ returns 200."""
+    response = client.get("/api/v1/seasons/", HTTP_ACCEPT="application/json")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_season_filter_by_league(client, nfl, ncaa, season_2024):
+    """GET /api/v1/seasons/?league=<id> filters by league."""
+    Season.objects.create(league=ncaa, year=2024, label="2024")
+    response = client.get(
+        f"/api/v1/seasons/?league={nfl.pk}", HTTP_ACCEPT="application/json"
+    )
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["league"] == nfl.pk
+
+
+@pytest.mark.django_db
+def test_season_filter_by_year(client, nfl, season_2024, season_2025):
+    """GET /api/v1/seasons/?year=2024 filters by year."""
+    response = client.get("/api/v1/seasons/?year=2024", HTTP_ACCEPT="application/json")
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["year"] == 2024
+
+
+@pytest.mark.django_db
+def test_season_retrieve_returns_detail(client, nfl, season_2024):
+    """GET /api/v1/seasons/<id>/ returns full detail."""
+    response = client.get(
+        f"/api/v1/seasons/{season_2024.pk}/", HTTP_ACCEPT="application/json"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["year"] == 2024
+    assert "bonus_data" in data
+    assert "external_ids" in data
+
+
+@pytest.mark.django_db
+def test_season_create(client, nfl):
+    """POST /api/v1/seasons/ creates a new season."""
+    response = client.post(
+        "/api/v1/seasons/",
+        data={"league": nfl.pk, "year": 2023, "label": "2023"},
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    assert Season.objects.filter(league=nfl, year=2023).exists()
+
+
+@pytest.mark.django_db
+def test_season_update(client, nfl, season_2024):
+    """PUT /api/v1/seasons/<id>/ updates the season."""
+    response = client.put(
+        f"/api/v1/seasons/{season_2024.pk}/",
+        data={"league": nfl.pk, "year": 2024, "label": "2024-25"},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    season_2024.refresh_from_db()
+    assert season_2024.label == "2024-25"
+
+
+@pytest.mark.django_db
+def test_season_delete_not_allowed(client, nfl, season_2024):
+    """DELETE /api/v1/seasons/<id>/ is not supported."""
+    response = client.delete(f"/api/v1/seasons/{season_2024.pk}/")
+    assert response.status_code == 405
+
+
+# --- N+1 query prevention ---
+
+
+@pytest.mark.django_db
+def test_season_list_uses_select_related(
+    client, nfl, season_2024, season_2025, django_assert_num_queries
+):
+    """Season list should not produce N+1 queries — single query via select_related JOIN."""
+    with django_assert_num_queries(1):
+        client.get("/api/v1/seasons/", HTTP_ACCEPT="application/json")
+
+
+# --- Router registration ---
+
+
+@pytest.mark.django_db
+def test_leagues_registered_on_router():
+    """LeagueViewSet must be registered at /leagues/."""
+    url = reverse("league-list")
+    assert url == "/api/v1/leagues/"
+
+
+@pytest.mark.django_db
+def test_seasons_registered_on_router():
+    """SeasonViewSet must be registered at /seasons/."""
+    url = reverse("season-list")
+    assert url == "/api/v1/seasons/"
+
+
+@pytest.mark.django_db
+def test_api_root_lists_endpoints(client):
+    """API root should now list leagues and seasons."""
+    response = client.get("/api/v1/", HTTP_ACCEPT="application/json")
+    data = response.json()
+    assert "leagues" in data
+    assert "seasons" in data


### PR DESCRIPTION
## Summary

- Implement `LeagueListSerializer` (id, long_name, short_name, level, seasons_count), `LeagueDetailSerializer` (all fields + nested seasons), and `LeagueWriteSerializer` for create/update
- Implement `SeasonListSerializer` (id, league, year, label, start_date, end_date), `SeasonDetailSerializer` (all fields), and `SeasonWriteSerializer`
- `LeagueViewSet` supports LIST, CREATE, RETRIEVE, UPDATE with `annotate(seasons_count)` on list and `prefetch_related("seasons")` on detail
- `SeasonViewSet` supports LIST, CREATE, RETRIEVE, UPDATE with `select_related("league")` and `DjangoFilterBackend` filters for `league` and `year`
- Register both viewsets on the router at `/leagues/` and `/seasons/`
- Add RUF012 per-file ignores for `serializers/` and `viewsets/` dirs (standard DRF mutable class attribute pattern)
- Add 24 tests covering all acceptance criteria

## Test plan

- [x] All 24 new League/Season API tests pass
- [x] Full test suite (154 tests) passes with no regressions
- [x] `manage.py check` reports no issues
- [x] `ruff check` and `ruff format` clean
- [x] N+1 query prevention verified: season list executes in 1 SQL query (select_related JOIN)

Closes #289