### PR TITLE
feat(GAM #290): add Franchise and Team serializers and viewsets

### DIFF
--- a/archive/api/router.py
+++ b/archive/api/router.py
@@ -1,10 +1,14 @@
 from rest_framework.routers import DefaultRouter
 
+from archive.api.viewsets.franchise import FranchiseViewSet
 from archive.api.viewsets.league import LeagueViewSet
 from archive.api.viewsets.season import SeasonViewSet
+from archive.api.viewsets.team import TeamViewSet
 
 router = DefaultRouter()
 router.register("leagues", LeagueViewSet, basename="league")
 router.register("seasons", SeasonViewSet, basename="season")
+router.register("franchises", FranchiseViewSet, basename="franchise")
+router.register("teams", TeamViewSet, basename="team")
 
 urlpatterns = router.urls

--- a/archive/api/serializers/franchise.py
+++ b/archive/api/serializers/franchise.py
@@ -1,0 +1,38 @@
+from rest_framework import serializers
+
+from archive.models import Franchise
+
+
+class FranchiseListSerializer(serializers.ModelSerializer):
+    league = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = Franchise
+        fields = ["id", "name", "league"]
+
+
+class FranchiseDetailSerializer(serializers.ModelSerializer):
+    league = serializers.PrimaryKeyRelatedField(read_only=True)
+    teams = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Franchise
+        fields = [
+            "id",
+            "name",
+            "league",
+            "bonus_data",
+            "external_ids",
+            "teams",
+        ]
+
+    def get_teams(self, obj):
+        from archive.api.serializers.team import TeamReferenceSerializer
+
+        return TeamReferenceSerializer(obj.teams.all(), many=True).data
+
+
+class FranchiseWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Franchise
+        fields = ["name", "league", "bonus_data", "external_ids"]

--- a/archive/api/serializers/team.py
+++ b/archive/api/serializers/team.py
@@ -1,0 +1,100 @@
+from rest_framework import serializers
+
+from archive.models import Team, TeamAffiliation, TeamVenueOccupancy
+
+
+class TeamReferenceSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Team
+        fields = ["id", "name", "short_name"]
+
+
+class TeamAffiliationInlineSerializer(serializers.ModelSerializer):
+    org_unit = serializers.StringRelatedField()
+    season = serializers.StringRelatedField()
+
+    class Meta:
+        model = TeamAffiliation
+        fields = ["id", "org_unit", "season", "start_date", "end_date"]
+
+
+class TeamVenueOccupancyInlineSerializer(serializers.ModelSerializer):
+    venue = serializers.StringRelatedField()
+
+    class Meta:
+        model = TeamVenueOccupancy
+        fields = ["id", "venue", "start_date", "end_date"]
+
+
+class TeamListSerializer(serializers.ModelSerializer):
+    franchise = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = Team
+        fields = [
+            "id",
+            "name",
+            "short_name",
+            "city",
+            "state",
+            "franchise",
+            "primary_color",
+            "secondary_color",
+        ]
+
+
+class TeamDetailSerializer(serializers.ModelSerializer):
+    franchise = serializers.PrimaryKeyRelatedField(read_only=True)
+    affiliations = TeamAffiliationInlineSerializer(many=True, read_only=True)
+    venue_occupancies = TeamVenueOccupancyInlineSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Team
+        fields = [
+            "id",
+            "franchise",
+            "name",
+            "alternate_name",
+            "short_name",
+            "city",
+            "state",
+            "country",
+            "era_start_date",
+            "era_end_date",
+            "school_name",
+            "mascot",
+            "logo",
+            "primary_color",
+            "secondary_color",
+            "tertiary_color",
+            "additional_colors",
+            "bonus_data",
+            "external_ids",
+            "affiliations",
+            "venue_occupancies",
+        ]
+
+
+class TeamWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Team
+        fields = [
+            "franchise",
+            "name",
+            "alternate_name",
+            "short_name",
+            "city",
+            "state",
+            "country",
+            "era_start_date",
+            "era_end_date",
+            "school_name",
+            "mascot",
+            "logo",
+            "primary_color",
+            "secondary_color",
+            "tertiary_color",
+            "additional_colors",
+            "bonus_data",
+            "external_ids",
+        ]

--- a/archive/api/viewsets/franchise.py
+++ b/archive/api/viewsets/franchise.py
@@ -1,0 +1,41 @@
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.mixins import (
+    CreateModelMixin,
+    ListModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+)
+from rest_framework.viewsets import GenericViewSet
+
+from archive.api.pagination import DefaultCursorPagination
+from archive.api.serializers.franchise import (
+    FranchiseDetailSerializer,
+    FranchiseListSerializer,
+    FranchiseWriteSerializer,
+)
+from archive.models import Franchise
+
+
+class FranchiseViewSet(
+    ListModelMixin,
+    CreateModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+    GenericViewSet,
+):
+    pagination_class = DefaultCursorPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["league"]
+
+    def get_queryset(self):
+        qs = Franchise.objects.select_related("league").all()
+        if self.action == "retrieve":
+            qs = qs.prefetch_related("teams")
+        return qs
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return FranchiseListSerializer
+        if self.action == "retrieve":
+            return FranchiseDetailSerializer
+        return FranchiseWriteSerializer

--- a/archive/api/viewsets/team.py
+++ b/archive/api/viewsets/team.py
@@ -1,0 +1,44 @@
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.filters import SearchFilter
+from rest_framework.mixins import (
+    CreateModelMixin,
+    ListModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+)
+from rest_framework.viewsets import GenericViewSet
+
+from archive.api.pagination import DefaultCursorPagination
+from archive.api.serializers.team import (
+    TeamDetailSerializer,
+    TeamListSerializer,
+    TeamWriteSerializer,
+)
+from archive.models import Team
+
+
+class TeamViewSet(
+    ListModelMixin,
+    CreateModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+    GenericViewSet,
+):
+    pagination_class = DefaultCursorPagination
+    filter_backends = [DjangoFilterBackend, SearchFilter]
+    filterset_fields = ["franchise", "city", "state"]
+    search_fields = ["name", "short_name", "city", "school_name", "mascot"]
+
+    def get_queryset(self):
+        return (
+            Team.objects.select_related("franchise")
+            .prefetch_related("affiliations", "venue_occupancies")
+            .all()
+        )
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return TeamListSerializer
+        if self.action == "retrieve":
+            return TeamDetailSerializer
+        return TeamWriteSerializer

--- a/tests/test_franchise_team_api.py
+++ b/tests/test_franchise_team_api.py
@@ -1,0 +1,441 @@
+"""Tests for Franchise and Team serializers and viewsets (TGF-290)."""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from archive.api.serializers.franchise import (
+    FranchiseDetailSerializer,
+    FranchiseListSerializer,
+)
+from archive.api.serializers.team import (
+    TeamDetailSerializer,
+    TeamListSerializer,
+    TeamReferenceSerializer,
+    TeamWriteSerializer,
+)
+from archive.models import (
+    Franchise,
+    League,
+    OrgUnit,
+    Season,
+    Team,
+    TeamAffiliation,
+    TeamVenueOccupancy,
+    Venue,
+)
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def nfl():
+    return League.objects.create(
+        short_name="NFL", long_name="National Football League", level="PRO"
+    )
+
+
+@pytest.fixture
+def steelers_franchise(nfl):
+    return Franchise.objects.create(name="Pittsburgh Steelers", league=nfl)
+
+
+@pytest.fixture
+def ravens_franchise(nfl):
+    return Franchise.objects.create(name="Baltimore Ravens", league=nfl)
+
+
+@pytest.fixture
+def steelers(steelers_franchise):
+    return Team.objects.create(
+        franchise=steelers_franchise,
+        name="Pittsburgh Steelers",
+        short_name="PIT",
+        city="Pittsburgh",
+        state="PA",
+        primary_color="FFB612",
+        secondary_color="101820",
+        mascot="Steely McBeam",
+    )
+
+
+@pytest.fixture
+def ravens(ravens_franchise):
+    return Team.objects.create(
+        franchise=ravens_franchise,
+        name="Baltimore Ravens",
+        short_name="BAL",
+        city="Baltimore",
+        state="MD",
+        primary_color="241773",
+        secondary_color="000000",
+    )
+
+
+@pytest.fixture
+def heinz_field():
+    return Venue.objects.create(
+        name="Heinz Field", city="Pittsburgh", state="PA", capacity=68400
+    )
+
+
+@pytest.fixture
+def steelers_venue_occupancy(steelers, heinz_field):
+    return TeamVenueOccupancy.objects.create(
+        team=steelers, venue=heinz_field, start_date="2001-08-18"
+    )
+
+
+@pytest.fixture
+def afc_north(nfl):
+    return OrgUnit.objects.create(
+        league=nfl, short_name="AFCN", long_name="AFC North", org_type="DIVISION"
+    )
+
+
+@pytest.fixture
+def season_2024(nfl):
+    return Season.objects.create(league=nfl, year=2024, label="2024")
+
+
+@pytest.fixture
+def steelers_affiliation(steelers, afc_north, season_2024):
+    return TeamAffiliation.objects.create(
+        team=steelers, org_unit=afc_north, season=season_2024
+    )
+
+
+# --- TeamReferenceSerializer ---
+
+
+@pytest.mark.django_db
+def test_team_reference_serializer_fields(steelers):
+    """TeamReferenceSerializer includes id, name, short_name only."""
+    serializer = TeamReferenceSerializer(steelers)
+    data = serializer.data
+    assert set(data.keys()) == {"id", "name", "short_name"}
+    assert data["name"] == "Pittsburgh Steelers"
+    assert data["short_name"] == "PIT"
+
+
+# --- FranchiseListSerializer ---
+
+
+@pytest.mark.django_db
+def test_franchise_list_serializer_fields(steelers_franchise, nfl):
+    """FranchiseListSerializer includes id, name, league."""
+    franchise = Franchise.objects.select_related("league").get(pk=steelers_franchise.pk)
+    serializer = FranchiseListSerializer(franchise)
+    data = serializer.data
+    assert data["id"] == steelers_franchise.pk
+    assert data["name"] == "Pittsburgh Steelers"
+    assert data["league"] == nfl.pk
+
+
+# --- FranchiseDetailSerializer ---
+
+
+@pytest.mark.django_db
+def test_franchise_detail_serializer_includes_teams(steelers_franchise, steelers):
+    """FranchiseDetailSerializer includes all fields plus nested teams."""
+    franchise = Franchise.objects.prefetch_related("teams").get(
+        pk=steelers_franchise.pk
+    )
+    serializer = FranchiseDetailSerializer(franchise)
+    data = serializer.data
+    assert data["name"] == "Pittsburgh Steelers"
+    assert "bonus_data" in data
+    assert "external_ids" in data
+    assert len(data["teams"]) == 1
+    assert data["teams"][0]["short_name"] == "PIT"
+
+
+# --- TeamListSerializer ---
+
+
+@pytest.mark.django_db
+def test_team_list_serializer_fields(steelers, steelers_franchise):
+    """TeamListSerializer includes id, name, short_name, city, state, franchise, colors."""
+    team = Team.objects.select_related("franchise").get(pk=steelers.pk)
+    serializer = TeamListSerializer(team)
+    data = serializer.data
+    assert data["id"] == steelers.pk
+    assert data["name"] == "Pittsburgh Steelers"
+    assert data["short_name"] == "PIT"
+    assert data["city"] == "Pittsburgh"
+    assert data["state"] == "PA"
+    assert data["franchise"] == steelers_franchise.pk
+    assert data["primary_color"] == "FFB612"
+    assert data["secondary_color"] == "101820"
+
+
+# --- TeamDetailSerializer ---
+
+
+@pytest.mark.django_db
+def test_team_detail_serializer_all_fields(
+    steelers, steelers_affiliation, steelers_venue_occupancy
+):
+    """TeamDetailSerializer includes all fields plus nested affiliations and venue_occupancies."""
+    team = (
+        Team.objects.select_related("franchise")
+        .prefetch_related("affiliations", "venue_occupancies")
+        .get(pk=steelers.pk)
+    )
+    serializer = TeamDetailSerializer(team)
+    data = serializer.data
+    assert data["name"] == "Pittsburgh Steelers"
+    assert data["mascot"] == "Steely McBeam"
+    assert "bonus_data" in data
+    assert "external_ids" in data
+    assert len(data["affiliations"]) == 1
+    assert len(data["venue_occupancies"]) == 1
+
+
+# --- TeamWriteSerializer ---
+
+
+@pytest.mark.django_db
+def test_team_write_serializer_accepts_franchise_pk(steelers_franchise):
+    """TeamWriteSerializer accepts integer PK for franchise FK."""
+    serializer = TeamWriteSerializer(
+        data={
+            "franchise": steelers_franchise.pk,
+            "name": "Pittsburgh Maulers",
+            "short_name": "MAU",
+        }
+    )
+    assert serializer.is_valid(), serializer.errors
+    team = serializer.save()
+    assert team.franchise == steelers_franchise
+
+
+# --- FranchiseViewSet endpoints ---
+
+
+@pytest.mark.django_db
+def test_franchise_list_returns_200(client, steelers_franchise):
+    """GET /api/v1/franchises/ returns 200."""
+    response = client.get("/api/v1/franchises/", HTTP_ACCEPT="application/json")
+    assert response.status_code == 200
+    assert "results" in response.json()
+
+
+@pytest.mark.django_db
+def test_franchise_filter_by_league(client, nfl, steelers_franchise):
+    """GET /api/v1/franchises/?league=<id> filters by league."""
+    ncaa = League.objects.create(
+        short_name="NCAA",
+        long_name="National Collegiate Athletic Association",
+        level="COLLEGE",
+    )
+    Franchise.objects.create(name="Georgia Bulldogs", league=ncaa)
+    response = client.get(
+        f"/api/v1/franchises/?league={nfl.pk}", HTTP_ACCEPT="application/json"
+    )
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["name"] == "Pittsburgh Steelers"
+
+
+@pytest.mark.django_db
+def test_franchise_retrieve(client, steelers_franchise, steelers):
+    """GET /api/v1/franchises/<id>/ returns detail with nested teams."""
+    response = client.get(
+        f"/api/v1/franchises/{steelers_franchise.pk}/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Pittsburgh Steelers"
+    assert len(data["teams"]) == 1
+
+
+@pytest.mark.django_db
+def test_franchise_create(client, nfl):
+    """POST /api/v1/franchises/ creates a franchise."""
+    response = client.post(
+        "/api/v1/franchises/",
+        data={"name": "Cleveland Browns", "league": nfl.pk},
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    assert Franchise.objects.filter(name="Cleveland Browns").exists()
+
+
+@pytest.mark.django_db
+def test_franchise_update(client, steelers_franchise, nfl):
+    """PUT /api/v1/franchises/<id>/ updates the franchise."""
+    response = client.put(
+        f"/api/v1/franchises/{steelers_franchise.pk}/",
+        data={"name": "Pittsburgh Steelers (Updated)", "league": nfl.pk},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    steelers_franchise.refresh_from_db()
+    assert steelers_franchise.name == "Pittsburgh Steelers (Updated)"
+
+
+@pytest.mark.django_db
+def test_franchise_delete_not_allowed(client, steelers_franchise):
+    """DELETE /api/v1/franchises/<id>/ is not supported."""
+    response = client.delete(f"/api/v1/franchises/{steelers_franchise.pk}/")
+    assert response.status_code == 405
+
+
+# --- TeamViewSet endpoints ---
+
+
+@pytest.mark.django_db
+def test_team_list_returns_200(client, steelers):
+    """GET /api/v1/teams/ returns 200."""
+    response = client.get("/api/v1/teams/", HTTP_ACCEPT="application/json")
+    assert response.status_code == 200
+    assert "results" in response.json()
+
+
+@pytest.mark.django_db
+def test_team_filter_by_franchise(client, steelers, ravens):
+    """GET /api/v1/teams/?franchise=<id> filters by franchise."""
+    response = client.get(
+        f"/api/v1/teams/?franchise={steelers.franchise.pk}",
+        HTTP_ACCEPT="application/json",
+    )
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["name"] == "Pittsburgh Steelers"
+
+
+@pytest.mark.django_db
+def test_team_filter_by_city(client, steelers, ravens):
+    """GET /api/v1/teams/?city=Pittsburgh filters by city."""
+    response = client.get(
+        "/api/v1/teams/?city=Pittsburgh", HTTP_ACCEPT="application/json"
+    )
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["city"] == "Pittsburgh"
+
+
+@pytest.mark.django_db
+def test_team_filter_by_state(client, steelers, ravens):
+    """GET /api/v1/teams/?state=PA filters by state."""
+    response = client.get("/api/v1/teams/?state=PA", HTTP_ACCEPT="application/json")
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["state"] == "PA"
+
+
+@pytest.mark.django_db
+def test_team_search_by_name(client, steelers, ravens):
+    """GET /api/v1/teams/?search=Steelers finds by name."""
+    response = client.get(
+        "/api/v1/teams/?search=Steelers", HTTP_ACCEPT="application/json"
+    )
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["name"] == "Pittsburgh Steelers"
+
+
+@pytest.mark.django_db
+def test_team_search_by_mascot(client, steelers, ravens):
+    """GET /api/v1/teams/?search=Steely finds by mascot."""
+    response = client.get(
+        "/api/v1/teams/?search=Steely", HTTP_ACCEPT="application/json"
+    )
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["name"] == "Pittsburgh Steelers"
+
+
+@pytest.mark.django_db
+def test_team_retrieve_returns_detail(
+    client, steelers, steelers_affiliation, steelers_venue_occupancy
+):
+    """GET /api/v1/teams/<id>/ returns detail with nested affiliations and venues."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/", HTTP_ACCEPT="application/json"
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["name"] == "Pittsburgh Steelers"
+    assert data["mascot"] == "Steely McBeam"
+    assert len(data["affiliations"]) == 1
+    assert len(data["venue_occupancies"]) == 1
+
+
+@pytest.mark.django_db
+def test_team_create(client, steelers_franchise):
+    """POST /api/v1/teams/ creates a team."""
+    response = client.post(
+        "/api/v1/teams/",
+        data={
+            "franchise": steelers_franchise.pk,
+            "name": "Pittsburgh Maulers",
+            "short_name": "MAU",
+            "city": "Pittsburgh",
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    assert Team.objects.filter(name="Pittsburgh Maulers").exists()
+
+
+@pytest.mark.django_db
+def test_team_update(client, steelers, steelers_franchise):
+    """PUT /api/v1/teams/<id>/ updates the team."""
+    response = client.put(
+        f"/api/v1/teams/{steelers.pk}/",
+        data={
+            "franchise": steelers_franchise.pk,
+            "name": "Pittsburgh Steelers",
+            "short_name": "PIT",
+            "city": "Pittsburgh",
+            "state": "PA",
+            "mascot": "Steely McBeam Jr.",
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    steelers.refresh_from_db()
+    assert steelers.mascot == "Steely McBeam Jr."
+
+
+@pytest.mark.django_db
+def test_team_delete_not_allowed(client, steelers):
+    """DELETE /api/v1/teams/<id>/ is not supported."""
+    response = client.delete(f"/api/v1/teams/{steelers.pk}/")
+    assert response.status_code == 405
+
+
+# --- N+1 query prevention ---
+
+
+@pytest.mark.django_db
+def test_team_list_uses_select_related(
+    client, steelers, ravens, django_assert_num_queries
+):
+    """Team list should not produce N+1 queries."""
+    # 1 query: teams JOIN franchise + 2 prefetches (affiliations, venue_occupancies)
+    with django_assert_num_queries(3):
+        client.get("/api/v1/teams/", HTTP_ACCEPT="application/json")
+
+
+# --- Router registration ---
+
+
+@pytest.mark.django_db
+def test_franchises_registered_on_router():
+    """FranchiseViewSet must be registered at /franchises/."""
+    url = reverse("franchise-list")
+    assert url == "/api/v1/franchises/"
+
+
+@pytest.mark.django_db
+def test_teams_registered_on_router():
+    """TeamViewSet must be registered at /teams/."""
+    url = reverse("team-list")
+    assert url == "/api/v1/teams/"


### PR DESCRIPTION
## Summary

- Implement `FranchiseListSerializer`, `FranchiseDetailSerializer` (with nested teams), and `FranchiseWriteSerializer`
- Implement `TeamReferenceSerializer` (id, name, short_name for nested FK use), `TeamListSerializer` (with franchise, city, state, colors), `TeamDetailSerializer` (all fields + nested affiliations and venue_occupancies), and `TeamWriteSerializer` (accepts integer PKs for franchise)
- `FranchiseViewSet` supports LIST, CREATE, RETRIEVE, UPDATE with `DjangoFilterBackend` filter by `league`
- `TeamViewSet` supports LIST, CREATE, RETRIEVE, UPDATE with `DjangoFilterBackend` filters (franchise, city, state) and `SearchFilter` (name, short_name, city, school_name, mascot)
- `TeamViewSet.get_queryset()` uses `select_related("franchise")` and `prefetch_related("affiliations", "venue_occupancies")`
- Register both viewsets on the router at `/franchises/` and `/teams/`
- Add 25 tests covering all acceptance criteria

## Test plan

- [x] All 25 new Franchise/Team API tests pass
- [x] Full test suite (179 tests) passes with no regressions
- [x] `manage.py check` reports no issues
- [x] `ruff check` and `ruff format` clean
- [x] N+1 prevention verified: team list executes in 3 queries (1 JOIN + 2 prefetches)

Closes #290