### PR TITLE
feat(GAM #295): add boxscore serializers and offensive stat endpoints

### DIFF
--- a/archive/api/router.py
+++ b/archive/api/router.py
@@ -1,6 +1,11 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
+from archive.api.viewsets.boxscore import (
+    PassingBoxscoreViewSet,
+    ReceivingBoxscoreViewSet,
+    RushingBoxscoreViewSet,
+)
 from archive.api.viewsets.franchise import FranchiseViewSet
 from archive.api.viewsets.game import GameViewSet
 from archive.api.viewsets.game_nested import (
@@ -46,6 +51,21 @@ game_nested_urls = [
         "games/<int:game_pk>/replays/",
         GameReplayViewSet.as_view({"get": "list", "post": "create"}),
         name="game-replays",
+    ),
+    path(
+        "games/<int:game_pk>/boxscores/passing/",
+        PassingBoxscoreViewSet.as_view({"get": "list", "post": "create"}),
+        name="game-boxscores-passing",
+    ),
+    path(
+        "games/<int:game_pk>/boxscores/rushing/",
+        RushingBoxscoreViewSet.as_view({"get": "list", "post": "create"}),
+        name="game-boxscores-rushing",
+    ),
+    path(
+        "games/<int:game_pk>/boxscores/receiving/",
+        ReceivingBoxscoreViewSet.as_view({"get": "list", "post": "create"}),
+        name="game-boxscores-receiving",
     ),
 ]
 

--- a/archive/api/serializers/boxscore.py
+++ b/archive/api/serializers/boxscore.py
@@ -1,0 +1,154 @@
+from rest_framework import serializers
+
+from archive.models import PassingBoxscore, ReceivingBoxscore, RushingBoxscore
+
+
+class PlayerGameStatBaseSerializer(serializers.Serializer):
+    """Abstract base defining shared fields for all boxscore serializers."""
+
+    id = serializers.IntegerField(read_only=True)
+    game = serializers.PrimaryKeyRelatedField(read_only=True)
+    team = serializers.PrimaryKeyRelatedField(read_only=True)
+    side = serializers.CharField(read_only=True)
+    player_name = serializers.CharField(read_only=True)
+    jersey_number = serializers.IntegerField(read_only=True)
+    position = serializers.CharField(read_only=True)
+
+
+class PassingBoxscoreSerializer(serializers.ModelSerializer):
+    team = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = PassingBoxscore
+        fields = [
+            "id",
+            "game",
+            "team",
+            "side",
+            "player_name",
+            "jersey_number",
+            "position",
+            "attempts",
+            "completions",
+            "completion_pct",
+            "yards",
+            "yards_per_attempt",
+            "touchdowns",
+            "interceptions",
+            "sacks",
+            "sack_yards",
+            "qb_rating",
+            "longest_pass",
+            "longest_td_pass",
+        ]
+        read_only_fields = ["id", "game"]
+
+
+class PassingBoxscoreWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PassingBoxscore
+        fields = [
+            "team",
+            "side",
+            "player_name",
+            "jersey_number",
+            "position",
+            "attempts",
+            "completions",
+            "completion_pct",
+            "yards",
+            "yards_per_attempt",
+            "touchdowns",
+            "interceptions",
+            "sacks",
+            "sack_yards",
+            "qb_rating",
+            "longest_pass",
+            "longest_td_pass",
+        ]
+
+
+class RushingBoxscoreSerializer(serializers.ModelSerializer):
+    team = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = RushingBoxscore
+        fields = [
+            "id",
+            "game",
+            "team",
+            "side",
+            "player_name",
+            "jersey_number",
+            "position",
+            "attempts",
+            "yards",
+            "avg_yards",
+            "touchdowns",
+            "longest_rush",
+            "longest_td_rush",
+        ]
+        read_only_fields = ["id", "game"]
+
+
+class RushingBoxscoreWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = RushingBoxscore
+        fields = [
+            "team",
+            "side",
+            "player_name",
+            "jersey_number",
+            "position",
+            "attempts",
+            "yards",
+            "avg_yards",
+            "touchdowns",
+            "longest_rush",
+            "longest_td_rush",
+        ]
+
+
+class ReceivingBoxscoreSerializer(serializers.ModelSerializer):
+    team = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = ReceivingBoxscore
+        fields = [
+            "id",
+            "game",
+            "team",
+            "side",
+            "player_name",
+            "jersey_number",
+            "position",
+            "receptions",
+            "yards",
+            "avg_yards",
+            "touchdowns",
+            "targets",
+            "longest_reception",
+            "longest_td_reception",
+            "yards_after_catch",
+        ]
+        read_only_fields = ["id", "game"]
+
+
+class ReceivingBoxscoreWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ReceivingBoxscore
+        fields = [
+            "team",
+            "side",
+            "player_name",
+            "jersey_number",
+            "position",
+            "receptions",
+            "yards",
+            "avg_yards",
+            "touchdowns",
+            "targets",
+            "longest_reception",
+            "longest_td_reception",
+            "yards_after_catch",
+        ]

--- a/archive/api/viewsets/boxscore.py
+++ b/archive/api/viewsets/boxscore.py
@@ -1,0 +1,55 @@
+from rest_framework.mixins import CreateModelMixin, ListModelMixin
+from rest_framework.viewsets import GenericViewSet
+
+from archive.api.serializers.boxscore import (
+    PassingBoxscoreSerializer,
+    PassingBoxscoreWriteSerializer,
+    ReceivingBoxscoreSerializer,
+    ReceivingBoxscoreWriteSerializer,
+    RushingBoxscoreSerializer,
+    RushingBoxscoreWriteSerializer,
+)
+from archive.api.viewsets.game_nested import GameNestedMixin
+from archive.models import PassingBoxscore, ReceivingBoxscore, RushingBoxscore
+
+
+class PassingBoxscoreViewSet(
+    GameNestedMixin, ListModelMixin, CreateModelMixin, GenericViewSet
+):
+    def get_queryset(self):
+        return PassingBoxscore.objects.filter(
+            game_id=self.kwargs["game_pk"]
+        ).select_related("team")
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return PassingBoxscoreWriteSerializer
+        return PassingBoxscoreSerializer
+
+
+class RushingBoxscoreViewSet(
+    GameNestedMixin, ListModelMixin, CreateModelMixin, GenericViewSet
+):
+    def get_queryset(self):
+        return RushingBoxscore.objects.filter(
+            game_id=self.kwargs["game_pk"]
+        ).select_related("team")
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return RushingBoxscoreWriteSerializer
+        return RushingBoxscoreSerializer
+
+
+class ReceivingBoxscoreViewSet(
+    GameNestedMixin, ListModelMixin, CreateModelMixin, GenericViewSet
+):
+    def get_queryset(self):
+        return ReceivingBoxscore.objects.filter(
+            game_id=self.kwargs["game_pk"]
+        ).select_related("team")
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return ReceivingBoxscoreWriteSerializer
+        return ReceivingBoxscoreSerializer

--- a/tests/test_boxscore_api.py
+++ b/tests/test_boxscore_api.py
@@ -1,0 +1,376 @@
+"""Tests for boxscore serializers and endpoints (TGF-295)."""
+
+import pytest
+from django.test import Client
+
+from archive.api.serializers.boxscore import (
+    PassingBoxscoreSerializer,
+    PlayerGameStatBaseSerializer,
+    ReceivingBoxscoreSerializer,
+    RushingBoxscoreSerializer,
+)
+from archive.models import (
+    Franchise,
+    Game,
+    League,
+    PassingBoxscore,
+    ReceivingBoxscore,
+    RushingBoxscore,
+    Season,
+    Team,
+    Venue,
+)
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def nfl():
+    return League.objects.create(
+        short_name="NFL", long_name="National Football League", level="PRO"
+    )
+
+
+@pytest.fixture
+def season_2024(nfl):
+    return Season.objects.create(league=nfl, year=2024, label="2024")
+
+
+@pytest.fixture
+def steelers_franchise(nfl):
+    return Franchise.objects.create(name="Pittsburgh Steelers", league=nfl)
+
+
+@pytest.fixture
+def ravens_franchise(nfl):
+    return Franchise.objects.create(name="Baltimore Ravens", league=nfl)
+
+
+@pytest.fixture
+def steelers(steelers_franchise):
+    return Team.objects.create(
+        franchise=steelers_franchise,
+        name="Pittsburgh Steelers",
+        short_name="PIT",
+        city="Pittsburgh",
+    )
+
+
+@pytest.fixture
+def ravens(ravens_franchise):
+    return Team.objects.create(
+        franchise=ravens_franchise,
+        name="Baltimore Ravens",
+        short_name="BAL",
+        city="Baltimore",
+    )
+
+
+@pytest.fixture
+def heinz_field():
+    return Venue.objects.create(
+        name="Heinz Field", city="Pittsburgh", state="PA", capacity=68400
+    )
+
+
+@pytest.fixture
+def game(nfl, season_2024, steelers, ravens, heinz_field):
+    return Game.objects.create(
+        league=nfl,
+        season=season_2024,
+        date_local="2024-09-08",
+        week=1,
+        home_team=steelers,
+        away_team=ravens,
+        venue=heinz_field,
+    )
+
+
+@pytest.fixture
+def other_game(nfl, season_2024, ravens, steelers, heinz_field):
+    return Game.objects.create(
+        league=nfl,
+        season=season_2024,
+        date_local="2024-09-15",
+        week=2,
+        home_team=ravens,
+        away_team=steelers,
+        venue=heinz_field,
+    )
+
+
+@pytest.fixture
+def passing_stat(game, steelers):
+    return PassingBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="Kenny Pickett",
+        jersey_number=8,
+        position="QB",
+        attempts=30,
+        completions=20,
+        completion_pct=66.7,
+        yards=250,
+        yards_per_attempt=8.3,
+        touchdowns=2,
+        interceptions=1,
+        sacks=2,
+        sack_yards=14,
+        qb_rating=92.5,
+    )
+
+
+@pytest.fixture
+def rushing_stat(game, steelers):
+    return RushingBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="Najee Harris",
+        jersey_number=22,
+        position="RB",
+        attempts=18,
+        yards=85,
+        avg_yards=4.7,
+        touchdowns=1,
+        longest_rush=22,
+    )
+
+
+@pytest.fixture
+def receiving_stat(game, steelers):
+    return ReceivingBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="George Pickens",
+        jersey_number=14,
+        position="WR",
+        receptions=6,
+        yards=110,
+        avg_yards=18.3,
+        touchdowns=1,
+        targets=9,
+        longest_reception=42,
+        yards_after_catch=35,
+    )
+
+
+# --- PlayerGameStatBaseSerializer ---
+
+
+def test_base_serializer_defines_shared_fields():
+    """PlayerGameStatBaseSerializer defines shared fields."""
+    fields = PlayerGameStatBaseSerializer().fields
+    expected = {
+        "id",
+        "game",
+        "team",
+        "side",
+        "player_name",
+        "jersey_number",
+        "position",
+    }
+    assert set(fields.keys()) == expected
+
+
+# --- PassingBoxscoreSerializer ---
+
+
+@pytest.mark.django_db
+def test_passing_serializer_fields(passing_stat):
+    """PassingBoxscoreSerializer includes base + passing-specific fields."""
+    stat = PassingBoxscore.objects.select_related("team").get(pk=passing_stat.pk)
+    serializer = PassingBoxscoreSerializer(stat)
+    data = serializer.data
+    assert data["player_name"] == "Kenny Pickett"
+    assert data["position"] == "QB"
+    assert data["attempts"] == 30
+    assert data["completions"] == 20
+    assert data["yards"] == 250
+    assert data["touchdowns"] == 2
+    assert data["interceptions"] == 1
+    assert data["qb_rating"] == 92.5
+
+
+# --- RushingBoxscoreSerializer ---
+
+
+@pytest.mark.django_db
+def test_rushing_serializer_fields(rushing_stat):
+    """RushingBoxscoreSerializer includes base + rushing-specific fields."""
+    stat = RushingBoxscore.objects.select_related("team").get(pk=rushing_stat.pk)
+    serializer = RushingBoxscoreSerializer(stat)
+    data = serializer.data
+    assert data["player_name"] == "Najee Harris"
+    assert data["attempts"] == 18
+    assert data["yards"] == 85
+    assert data["avg_yards"] == 4.7
+    assert data["touchdowns"] == 1
+    assert data["longest_rush"] == 22
+
+
+# --- ReceivingBoxscoreSerializer ---
+
+
+@pytest.mark.django_db
+def test_receiving_serializer_fields(receiving_stat):
+    """ReceivingBoxscoreSerializer includes base + receiving-specific fields."""
+    stat = ReceivingBoxscore.objects.select_related("team").get(pk=receiving_stat.pk)
+    serializer = ReceivingBoxscoreSerializer(stat)
+    data = serializer.data
+    assert data["player_name"] == "George Pickens"
+    assert data["receptions"] == 6
+    assert data["yards"] == 110
+    assert data["touchdowns"] == 1
+    assert data["targets"] == 9
+    assert data["yards_after_catch"] == 35
+
+
+# --- Passing endpoint ---
+
+
+@pytest.mark.django_db
+def test_passing_list(client, game, passing_stat):
+    """GET /api/v1/games/<id>/boxscores/passing/ returns passing stats."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/boxscores/passing/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["player_name"] == "Kenny Pickett"
+
+
+@pytest.mark.django_db
+def test_passing_scoped_to_game(client, game, other_game, passing_stat, ravens):
+    """Passing endpoint only returns stats for the specified game."""
+    PassingBoxscore.objects.create(
+        game=other_game,
+        team=ravens,
+        side="home",
+        player_name="Lamar Jackson",
+        position="QB",
+        attempts=25,
+        completions=18,
+        yards=280,
+    )
+    response = client.get(
+        f"/api/v1/games/{game.pk}/boxscores/passing/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert len(response.json()) == 1
+
+
+@pytest.mark.django_db
+def test_passing_create(client, game, steelers):
+    """POST /api/v1/games/<id>/boxscores/passing/ creates a passing stat."""
+    response = client.post(
+        f"/api/v1/games/{game.pk}/boxscores/passing/",
+        data={
+            "team": steelers.pk,
+            "side": "home",
+            "player_name": "Mason Rudolph",
+            "position": "QB",
+            "attempts": 5,
+            "completions": 3,
+            "yards": 45,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    assert PassingBoxscore.objects.filter(
+        game=game, player_name="Mason Rudolph"
+    ).exists()
+
+
+# --- Rushing endpoint ---
+
+
+@pytest.mark.django_db
+def test_rushing_list(client, game, rushing_stat):
+    """GET /api/v1/games/<id>/boxscores/rushing/ returns rushing stats."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/boxscores/rushing/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["player_name"] == "Najee Harris"
+
+
+@pytest.mark.django_db
+def test_rushing_create(client, game, steelers):
+    """POST /api/v1/games/<id>/boxscores/rushing/ creates a rushing stat."""
+    response = client.post(
+        f"/api/v1/games/{game.pk}/boxscores/rushing/",
+        data={
+            "team": steelers.pk,
+            "side": "home",
+            "player_name": "Jaylen Warren",
+            "position": "RB",
+            "attempts": 10,
+            "yards": 42,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    assert RushingBoxscore.objects.filter(
+        game=game, player_name="Jaylen Warren"
+    ).exists()
+
+
+# --- Receiving endpoint ---
+
+
+@pytest.mark.django_db
+def test_receiving_list(client, game, receiving_stat):
+    """GET /api/v1/games/<id>/boxscores/receiving/ returns receiving stats."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/boxscores/receiving/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    assert response.json()[0]["player_name"] == "George Pickens"
+
+
+@pytest.mark.django_db
+def test_receiving_create(client, game, steelers):
+    """POST /api/v1/games/<id>/boxscores/receiving/ creates a receiving stat."""
+    response = client.post(
+        f"/api/v1/games/{game.pk}/boxscores/receiving/",
+        data={
+            "team": steelers.pk,
+            "side": "home",
+            "player_name": "Pat Freiermuth",
+            "position": "TE",
+            "receptions": 4,
+            "yards": 38,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    assert ReceivingBoxscore.objects.filter(
+        game=game, player_name="Pat Freiermuth"
+    ).exists()
+
+
+# --- select_related verification ---
+
+
+@pytest.mark.django_db
+def test_passing_uses_select_related(
+    client, game, passing_stat, django_assert_num_queries
+):
+    """Passing endpoint uses select_related('team')."""
+    with django_assert_num_queries(1):
+        client.get(
+            f"/api/v1/games/{game.pk}/boxscores/passing/",
+            HTTP_ACCEPT="application/json",
+        )


### PR DESCRIPTION
## Summary

- Implement `PlayerGameStatBaseSerializer` defining shared fields: id, game, team, side, player_name, jersey_number, position
- Implement `PassingBoxscoreSerializer` with passing-specific fields (attempts, completions, completion_pct, yards, yards_per_attempt, touchdowns, interceptions, sacks, sack_yards, qb_rating, longest_pass, longest_td_pass)
- Implement `RushingBoxscoreSerializer` with rushing-specific fields (attempts, yards, avg_yards, touchdowns, longest_rush, longest_td_rush)
- Implement `ReceivingBoxscoreSerializer` with receiving-specific fields (receptions, yards, avg_yards, touchdowns, targets, longest_reception, longest_td_reception, yards_after_catch)
- Nested endpoints at `/games/{id}/boxscores/passing/`, `/games/{id}/boxscores/rushing/`, `/games/{id}/boxscores/receiving/` supporting LIST and CREATE
- All endpoints scope queryset to parent game ID and use `select_related("team")`
- Reuse `GameNestedMixin` from TGF-294 for game lookup and create injection
- Add 12 tests covering all acceptance criteria

## Test plan

- [x] All 12 new boxscore API tests pass
- [x] Full test suite (267 tests) passes with no regressions
- [x] `manage.py check` reports no issues
- [x] `ruff check` and `ruff format` clean
- [x] `select_related("team")` verified via `django_assert_num_queries(1)` test

Closes #295