### PR TITLE
feat(GAM #297): add special teams boxscore serializers and endpoints

### DIFF
--- a/archive/api/router.py
+++ b/archive/api/router.py
@@ -8,6 +8,13 @@ from archive.api.viewsets.boxscore import (
     RushingBoxscoreViewSet,
     TacklesBoxscoreViewSet,
 )
+from archive.api.viewsets.boxscore_special_teams import (
+    ExtraPointsBoxscoreViewSet,
+    FieldGoalsBoxscoreViewSet,
+    KickingBoxscoreViewSet,
+    PuntingBoxscoreViewSet,
+    ReturnBoxscoreViewSet,
+)
 from archive.api.viewsets.franchise import FranchiseViewSet
 from archive.api.viewsets.game import GameViewSet
 from archive.api.viewsets.game_nested import (
@@ -78,6 +85,31 @@ game_nested_urls = [
         "games/<int:game_pk>/boxscores/fumbles/",
         FumblesBoxscoreViewSet.as_view({"get": "list", "post": "create"}),
         name="game-boxscores-fumbles",
+    ),
+    path(
+        "games/<int:game_pk>/boxscores/field-goals/",
+        FieldGoalsBoxscoreViewSet.as_view({"get": "list", "post": "create"}),
+        name="game-boxscores-field-goals",
+    ),
+    path(
+        "games/<int:game_pk>/boxscores/extra-points/",
+        ExtraPointsBoxscoreViewSet.as_view({"get": "list", "post": "create"}),
+        name="game-boxscores-extra-points",
+    ),
+    path(
+        "games/<int:game_pk>/boxscores/kicking/",
+        KickingBoxscoreViewSet.as_view({"get": "list", "post": "create"}),
+        name="game-boxscores-kicking",
+    ),
+    path(
+        "games/<int:game_pk>/boxscores/punting/",
+        PuntingBoxscoreViewSet.as_view({"get": "list", "post": "create"}),
+        name="game-boxscores-punting",
+    ),
+    path(
+        "games/<int:game_pk>/boxscores/returns/",
+        ReturnBoxscoreViewSet.as_view({"get": "list", "post": "create"}),
+        name="game-boxscores-returns",
     ),
 ]
 

--- a/archive/api/serializers/boxscore_special_teams.py
+++ b/archive/api/serializers/boxscore_special_teams.py
@@ -1,0 +1,193 @@
+from rest_framework import serializers
+
+from archive.models import (
+    ExtraPointsBoxscore,
+    FieldGoalsBoxscore,
+    KickingBoxscore,
+    PuntingBoxscore,
+    ReturnBoxscore,
+)
+
+BASE_FIELDS = [
+    "id",
+    "game",
+    "team",
+    "side",
+    "player_name",
+    "jersey_number",
+    "position",
+]
+
+BASE_WRITE_FIELDS = [
+    "team",
+    "side",
+    "player_name",
+    "jersey_number",
+    "position",
+]
+
+
+# --- FieldGoals ---
+
+
+class FieldGoalsBoxscoreSerializer(serializers.ModelSerializer):
+    team = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = FieldGoalsBoxscore
+        fields = [
+            *BASE_FIELDS,
+            "attempts",
+            "made",
+            "blocked",
+            "yards",
+            "avg_yards",
+            "longest",
+        ]
+        read_only_fields = ["id", "game"]
+
+
+class FieldGoalsBoxscoreWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FieldGoalsBoxscore
+        fields = [
+            *BASE_WRITE_FIELDS,
+            "attempts",
+            "made",
+            "blocked",
+            "yards",
+            "avg_yards",
+            "longest",
+        ]
+
+
+# --- ExtraPoints ---
+
+
+class ExtraPointsBoxscoreSerializer(serializers.ModelSerializer):
+    team = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = ExtraPointsBoxscore
+        fields = [*BASE_FIELDS, "attempts", "made", "blocked"]
+        read_only_fields = ["id", "game"]
+
+
+class ExtraPointsBoxscoreWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ExtraPointsBoxscore
+        fields = [*BASE_WRITE_FIELDS, "attempts", "made", "blocked"]
+
+
+# --- Kicking ---
+
+
+class KickingBoxscoreSerializer(serializers.ModelSerializer):
+    team = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = KickingBoxscore
+        fields = [
+            *BASE_FIELDS,
+            "kickoffs",
+            "yards",
+            "touchbacks",
+            "inside_20",
+            "out_of_bounds",
+            "to_endzone",
+            "return_yards",
+        ]
+        read_only_fields = ["id", "game"]
+
+
+class KickingBoxscoreWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = KickingBoxscore
+        fields = [
+            *BASE_WRITE_FIELDS,
+            "kickoffs",
+            "yards",
+            "touchbacks",
+            "inside_20",
+            "out_of_bounds",
+            "to_endzone",
+            "return_yards",
+        ]
+
+
+# --- Punting ---
+
+
+class PuntingBoxscoreSerializer(serializers.ModelSerializer):
+    team = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = PuntingBoxscore
+        fields = [
+            *BASE_FIELDS,
+            "attempts",
+            "yards",
+            "gross_avg",
+            "net_avg",
+            "blocked",
+            "longest",
+            "touchbacks",
+            "inside_20",
+            "return_yards",
+        ]
+        read_only_fields = ["id", "game"]
+
+
+class PuntingBoxscoreWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = PuntingBoxscore
+        fields = [
+            *BASE_WRITE_FIELDS,
+            "attempts",
+            "yards",
+            "gross_avg",
+            "net_avg",
+            "blocked",
+            "longest",
+            "touchbacks",
+            "inside_20",
+            "return_yards",
+        ]
+
+
+# --- Returns ---
+
+
+class ReturnBoxscoreSerializer(serializers.ModelSerializer):
+    team = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = ReturnBoxscore
+        fields = [
+            *BASE_FIELDS,
+            "return_type",
+            "returns",
+            "yards",
+            "avg_yards",
+            "touchdowns",
+            "longest",
+            "longest_td",
+            "fair_catches",
+        ]
+        read_only_fields = ["id", "game"]
+
+
+class ReturnBoxscoreWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ReturnBoxscore
+        fields = [
+            *BASE_WRITE_FIELDS,
+            "return_type",
+            "returns",
+            "yards",
+            "avg_yards",
+            "touchdowns",
+            "longest",
+            "longest_td",
+            "fair_catches",
+        ]

--- a/archive/api/viewsets/boxscore_special_teams.py
+++ b/archive/api/viewsets/boxscore_special_teams.py
@@ -1,0 +1,93 @@
+from rest_framework.mixins import CreateModelMixin, ListModelMixin
+from rest_framework.viewsets import GenericViewSet
+
+from archive.api.serializers.boxscore_special_teams import (
+    ExtraPointsBoxscoreSerializer,
+    ExtraPointsBoxscoreWriteSerializer,
+    FieldGoalsBoxscoreSerializer,
+    FieldGoalsBoxscoreWriteSerializer,
+    KickingBoxscoreSerializer,
+    KickingBoxscoreWriteSerializer,
+    PuntingBoxscoreSerializer,
+    PuntingBoxscoreWriteSerializer,
+    ReturnBoxscoreSerializer,
+    ReturnBoxscoreWriteSerializer,
+)
+from archive.api.viewsets.game_nested import GameNestedMixin
+from archive.models import (
+    ExtraPointsBoxscore,
+    FieldGoalsBoxscore,
+    KickingBoxscore,
+    PuntingBoxscore,
+    ReturnBoxscore,
+)
+
+
+class FieldGoalsBoxscoreViewSet(
+    GameNestedMixin, ListModelMixin, CreateModelMixin, GenericViewSet
+):
+    def get_queryset(self):
+        return FieldGoalsBoxscore.objects.filter(
+            game_id=self.kwargs["game_pk"]
+        ).select_related("team")
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return FieldGoalsBoxscoreWriteSerializer
+        return FieldGoalsBoxscoreSerializer
+
+
+class ExtraPointsBoxscoreViewSet(
+    GameNestedMixin, ListModelMixin, CreateModelMixin, GenericViewSet
+):
+    def get_queryset(self):
+        return ExtraPointsBoxscore.objects.filter(
+            game_id=self.kwargs["game_pk"]
+        ).select_related("team")
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return ExtraPointsBoxscoreWriteSerializer
+        return ExtraPointsBoxscoreSerializer
+
+
+class KickingBoxscoreViewSet(
+    GameNestedMixin, ListModelMixin, CreateModelMixin, GenericViewSet
+):
+    def get_queryset(self):
+        return KickingBoxscore.objects.filter(
+            game_id=self.kwargs["game_pk"]
+        ).select_related("team")
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return KickingBoxscoreWriteSerializer
+        return KickingBoxscoreSerializer
+
+
+class PuntingBoxscoreViewSet(
+    GameNestedMixin, ListModelMixin, CreateModelMixin, GenericViewSet
+):
+    def get_queryset(self):
+        return PuntingBoxscore.objects.filter(
+            game_id=self.kwargs["game_pk"]
+        ).select_related("team")
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return PuntingBoxscoreWriteSerializer
+        return PuntingBoxscoreSerializer
+
+
+class ReturnBoxscoreViewSet(
+    GameNestedMixin, ListModelMixin, CreateModelMixin, GenericViewSet
+):
+    def get_queryset(self):
+        return ReturnBoxscore.objects.filter(
+            game_id=self.kwargs["game_pk"]
+        ).select_related("team")
+
+    def get_serializer_class(self):
+        if self.action == "create":
+            return ReturnBoxscoreWriteSerializer
+        return ReturnBoxscoreSerializer

--- a/tests/test_special_teams_boxscore_api.py
+++ b/tests/test_special_teams_boxscore_api.py
@@ -1,0 +1,427 @@
+"""Tests for special teams boxscore serializers and endpoints (TGF-297)."""
+
+import pytest
+from django.test import Client
+
+from archive.api.serializers.boxscore_special_teams import (
+    ExtraPointsBoxscoreSerializer,
+    FieldGoalsBoxscoreSerializer,
+    KickingBoxscoreSerializer,
+    PuntingBoxscoreSerializer,
+    ReturnBoxscoreSerializer,
+)
+from archive.models import (
+    ExtraPointsBoxscore,
+    FieldGoalsBoxscore,
+    Franchise,
+    Game,
+    KickingBoxscore,
+    League,
+    PuntingBoxscore,
+    ReturnBoxscore,
+    Season,
+    Team,
+    Venue,
+)
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def nfl():
+    return League.objects.create(
+        short_name="NFL", long_name="National Football League", level="PRO"
+    )
+
+
+@pytest.fixture
+def season_2024(nfl):
+    return Season.objects.create(league=nfl, year=2024, label="2024")
+
+
+@pytest.fixture
+def steelers_franchise(nfl):
+    return Franchise.objects.create(name="Pittsburgh Steelers", league=nfl)
+
+
+@pytest.fixture
+def ravens_franchise(nfl):
+    return Franchise.objects.create(name="Baltimore Ravens", league=nfl)
+
+
+@pytest.fixture
+def steelers(steelers_franchise):
+    return Team.objects.create(
+        franchise=steelers_franchise,
+        name="Pittsburgh Steelers",
+        short_name="PIT",
+        city="Pittsburgh",
+    )
+
+
+@pytest.fixture
+def ravens(ravens_franchise):
+    return Team.objects.create(
+        franchise=ravens_franchise,
+        name="Baltimore Ravens",
+        short_name="BAL",
+        city="Baltimore",
+    )
+
+
+@pytest.fixture
+def heinz_field():
+    return Venue.objects.create(
+        name="Heinz Field", city="Pittsburgh", state="PA", capacity=68400
+    )
+
+
+@pytest.fixture
+def game(nfl, season_2024, steelers, ravens, heinz_field):
+    return Game.objects.create(
+        league=nfl,
+        season=season_2024,
+        date_local="2024-09-08",
+        week=1,
+        home_team=steelers,
+        away_team=ravens,
+        venue=heinz_field,
+    )
+
+
+@pytest.fixture
+def fg_stat(game, steelers):
+    return FieldGoalsBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="Chris Boswell",
+        jersey_number=9,
+        position="K",
+        attempts=3,
+        made=2,
+        blocked=0,
+        yards=95,
+        longest=48,
+    )
+
+
+@pytest.fixture
+def xp_stat(game, steelers):
+    return ExtraPointsBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="Chris Boswell",
+        jersey_number=9,
+        position="K",
+        attempts=3,
+        made=3,
+    )
+
+
+@pytest.fixture
+def kicking_stat(game, steelers):
+    return KickingBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="Chris Boswell",
+        jersey_number=9,
+        position="K",
+        kickoffs=5,
+        yards=325,
+        touchbacks=3,
+    )
+
+
+@pytest.fixture
+def punting_stat(game, steelers):
+    return PuntingBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="Pressley Harvin III",
+        jersey_number=6,
+        position="P",
+        attempts=4,
+        yards=180,
+        gross_avg=45.0,
+        net_avg=40.5,
+        longest=55,
+        inside_20=2,
+    )
+
+
+@pytest.fixture
+def return_stat(game, steelers):
+    return ReturnBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="Gunner Olszewski",
+        jersey_number=89,
+        position="WR",
+        return_type="punt",
+        returns=3,
+        yards=45,
+        avg_yards=15.0,
+        fair_catches=2,
+    )
+
+
+# --- Serializer field tests ---
+
+
+@pytest.mark.django_db
+def test_field_goals_serializer_fields(fg_stat):
+    """FieldGoalsBoxscoreSerializer includes base + field goal fields."""
+    stat = FieldGoalsBoxscore.objects.select_related("team").get(pk=fg_stat.pk)
+    data = FieldGoalsBoxscoreSerializer(stat).data
+    assert data["player_name"] == "Chris Boswell"
+    assert data["attempts"] == 3
+    assert data["made"] == 2
+    assert data["longest"] == 48
+
+
+@pytest.mark.django_db
+def test_extra_points_serializer_fields(xp_stat):
+    """ExtraPointsBoxscoreSerializer includes base + extra point fields."""
+    stat = ExtraPointsBoxscore.objects.select_related("team").get(pk=xp_stat.pk)
+    data = ExtraPointsBoxscoreSerializer(stat).data
+    assert data["player_name"] == "Chris Boswell"
+    assert data["attempts"] == 3
+    assert data["made"] == 3
+
+
+@pytest.mark.django_db
+def test_kicking_serializer_fields(kicking_stat):
+    """KickingBoxscoreSerializer includes base + kicking fields."""
+    stat = KickingBoxscore.objects.select_related("team").get(pk=kicking_stat.pk)
+    data = KickingBoxscoreSerializer(stat).data
+    assert data["kickoffs"] == 5
+    assert data["touchbacks"] == 3
+
+
+@pytest.mark.django_db
+def test_punting_serializer_fields(punting_stat):
+    """PuntingBoxscoreSerializer includes base + punting fields."""
+    stat = PuntingBoxscore.objects.select_related("team").get(pk=punting_stat.pk)
+    data = PuntingBoxscoreSerializer(stat).data
+    assert data["player_name"] == "Pressley Harvin III"
+    assert data["attempts"] == 4
+    assert data["gross_avg"] == 45.0
+    assert data["inside_20"] == 2
+
+
+@pytest.mark.django_db
+def test_return_serializer_fields(return_stat):
+    """ReturnBoxscoreSerializer includes base + return fields."""
+    stat = ReturnBoxscore.objects.select_related("team").get(pk=return_stat.pk)
+    data = ReturnBoxscoreSerializer(stat).data
+    assert data["return_type"] == "punt"
+    assert data["returns"] == 3
+    assert data["fair_catches"] == 2
+
+
+# --- Endpoint LIST tests ---
+
+
+@pytest.mark.django_db
+def test_field_goals_list(client, game, fg_stat):
+    """GET /api/v1/games/<id>/boxscores/field-goals/ returns stats."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/boxscores/field-goals/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+@pytest.mark.django_db
+def test_extra_points_list(client, game, xp_stat):
+    """GET /api/v1/games/<id>/boxscores/extra-points/ returns stats."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/boxscores/extra-points/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+@pytest.mark.django_db
+def test_kicking_list(client, game, kicking_stat):
+    """GET /api/v1/games/<id>/boxscores/kicking/ returns stats."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/boxscores/kicking/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+@pytest.mark.django_db
+def test_punting_list(client, game, punting_stat):
+    """GET /api/v1/games/<id>/boxscores/punting/ returns stats."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/boxscores/punting/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+@pytest.mark.django_db
+def test_returns_list(client, game, return_stat):
+    """GET /api/v1/games/<id>/boxscores/returns/ returns stats."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/boxscores/returns/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+# --- Endpoint CREATE tests ---
+
+
+@pytest.mark.django_db
+def test_field_goals_create(client, game, steelers):
+    """POST /api/v1/games/<id>/boxscores/field-goals/ creates a stat."""
+    response = client.post(
+        f"/api/v1/games/{game.pk}/boxscores/field-goals/",
+        data={
+            "team": steelers.pk,
+            "side": "home",
+            "player_name": "Kicker",
+            "position": "K",
+            "attempts": 1,
+            "made": 1,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.django_db
+def test_extra_points_create(client, game, steelers):
+    """POST /api/v1/games/<id>/boxscores/extra-points/ creates a stat."""
+    response = client.post(
+        f"/api/v1/games/{game.pk}/boxscores/extra-points/",
+        data={
+            "team": steelers.pk,
+            "side": "home",
+            "player_name": "Kicker",
+            "position": "K",
+            "attempts": 2,
+            "made": 2,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.django_db
+def test_kicking_create(client, game, steelers):
+    """POST /api/v1/games/<id>/boxscores/kicking/ creates a stat."""
+    response = client.post(
+        f"/api/v1/games/{game.pk}/boxscores/kicking/",
+        data={
+            "team": steelers.pk,
+            "side": "home",
+            "player_name": "Kicker",
+            "position": "K",
+            "kickoffs": 3,
+            "yards": 195,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.django_db
+def test_punting_create(client, game, steelers):
+    """POST /api/v1/games/<id>/boxscores/punting/ creates a stat."""
+    response = client.post(
+        f"/api/v1/games/{game.pk}/boxscores/punting/",
+        data={
+            "team": steelers.pk,
+            "side": "home",
+            "player_name": "Punter",
+            "position": "P",
+            "attempts": 3,
+            "yards": 135,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+
+
+@pytest.mark.django_db
+def test_returns_create(client, game, steelers):
+    """POST /api/v1/games/<id>/boxscores/returns/ creates a stat."""
+    response = client.post(
+        f"/api/v1/games/{game.pk}/boxscores/returns/",
+        data={
+            "team": steelers.pk,
+            "side": "home",
+            "player_name": "Returner",
+            "position": "WR",
+            "return_type": "kick",
+            "returns": 2,
+            "yards": 50,
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+
+
+# --- Game scoping ---
+
+
+@pytest.mark.django_db
+def test_field_goals_scoped_to_game(
+    client, game, fg_stat, nfl, season_2024, steelers, ravens, heinz_field
+):
+    """Field goals endpoint only returns stats for the specified game."""
+    other_game = Game.objects.create(
+        league=nfl,
+        season=season_2024,
+        date_local="2024-09-15",
+        week=2,
+        home_team=ravens,
+        away_team=steelers,
+        venue=heinz_field,
+    )
+    FieldGoalsBoxscore.objects.create(
+        game=other_game,
+        team=ravens,
+        side="home",
+        player_name="Justin Tucker",
+        position="K",
+        attempts=2,
+        made=2,
+    )
+    response = client.get(
+        f"/api/v1/games/{game.pk}/boxscores/field-goals/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert len(response.json()) == 1
+
+
+# --- select_related verification ---
+
+
+@pytest.mark.django_db
+def test_field_goals_uses_select_related(
+    client, game, fg_stat, django_assert_num_queries
+):
+    """Field goals endpoint uses select_related('team')."""
+    with django_assert_num_queries(1):
+        client.get(
+            f"/api/v1/games/{game.pk}/boxscores/field-goals/",
+            HTTP_ACCEPT="application/json",
+        )


### PR DESCRIPTION
## Summary

- Implement `FieldGoalsBoxscoreSerializer` (attempts, made, blocked, yards, avg_yards, longest)
- Implement `ExtraPointsBoxscoreSerializer` (attempts, made, blocked)
- Implement `KickingBoxscoreSerializer` (kickoffs, yards, touchbacks, inside_20, out_of_bounds, to_endzone, return_yards)
- Implement `PuntingBoxscoreSerializer` (attempts, yards, gross_avg, net_avg, blocked, longest, touchbacks, inside_20, return_yards)
- Implement `ReturnBoxscoreSerializer` (return_type, returns, yards, avg_yards, touchdowns, longest, longest_td, fair_catches)
- 5 nested endpoints at `/games/{id}/boxscores/{field-goals,extra-points,kicking,punting,returns}/` supporting LIST and CREATE
- All scope queryset to parent game ID and use `select_related("team")`
- Uses `[*BASE_FIELDS, ...]` unpacking to DRY up shared field lists
- Add 17 tests covering all acceptance criteria

## Test plan

- [x] All 17 new special teams boxscore API tests pass
- [x] Full test suite (293 tests) passes with no regressions
- [x] `manage.py check` reports no issues
- [x] `ruff check` and `ruff format` clean
- [x] `select_related("team")` verified via `django_assert_num_queries(1)` test

Closes #297