### PR TITLE
feat(GAM #302): add Source and Acquisition serializers and viewsets

### DIFF
--- a/archive/api/router.py
+++ b/archive/api/router.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
+from archive.api.viewsets.acquisition import AcquisitionViewSet
 from archive.api.viewsets.boxscore import (
     FumblesBoxscoreViewSet,
     PassingBoxscoreViewSet,
@@ -27,6 +28,7 @@ from archive.api.viewsets.org_unit import OrgUnitViewSet
 from archive.api.viewsets.play import GamePlayViewSet
 from archive.api.viewsets.play_stat import PlayStatViewSet
 from archive.api.viewsets.season import SeasonViewSet
+from archive.api.viewsets.source import SourceViewSet
 from archive.api.viewsets.standings import TeamStandingsSnapshotViewSet
 from archive.api.viewsets.team import TeamViewSet
 from archive.api.viewsets.team_affiliation import TeamAffiliationViewSet
@@ -48,6 +50,8 @@ router.register(
 )
 router.register("games", GameViewSet, basename="game")
 router.register("standings", TeamStandingsSnapshotViewSet, basename="standings")
+router.register("sources", SourceViewSet, basename="source")
+router.register("acquisitions", AcquisitionViewSet, basename="acquisition")
 
 game_nested_urls = [
     path(

--- a/archive/api/serializers/acquisition.py
+++ b/archive/api/serializers/acquisition.py
@@ -1,0 +1,44 @@
+from rest_framework import serializers
+
+from archive.models import Acquisition
+
+
+class AcquisitionListSerializer(serializers.ModelSerializer):
+    source = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = Acquisition
+        fields = ["id", "source", "acquired_on", "rights", "cost_usd"]
+
+
+class AcquisitionDetailSerializer(serializers.ModelSerializer):
+    source = serializers.PrimaryKeyRelatedField(read_only=True)
+
+    class Meta:
+        model = Acquisition
+        fields = [
+            "id",
+            "source",
+            "acquired_on",
+            "cost_usd",
+            "rights",
+            "notes",
+            "proof_path",
+            "bonus_data",
+            "external_ids",
+        ]
+
+
+class AcquisitionWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Acquisition
+        fields = [
+            "source",
+            "acquired_on",
+            "cost_usd",
+            "rights",
+            "notes",
+            "proof_path",
+            "bonus_data",
+            "external_ids",
+        ]

--- a/archive/api/serializers/source.py
+++ b/archive/api/serializers/source.py
@@ -1,0 +1,36 @@
+from rest_framework import serializers
+
+from archive.models import Source
+
+
+class SourceListSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Source
+        fields = ["id", "name", "source_type", "url"]
+
+
+class SourceDetailSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Source
+        fields = [
+            "id",
+            "name",
+            "source_type",
+            "url",
+            "notes",
+            "bonus_data",
+            "external_ids",
+        ]
+
+
+class SourceWriteSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Source
+        fields = [
+            "name",
+            "source_type",
+            "url",
+            "notes",
+            "bonus_data",
+            "external_ids",
+        ]

--- a/archive/api/viewsets/acquisition.py
+++ b/archive/api/viewsets/acquisition.py
@@ -1,0 +1,26 @@
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.viewsets import ModelViewSet
+
+from archive.api.pagination import DefaultCursorPagination
+from archive.api.serializers.acquisition import (
+    AcquisitionDetailSerializer,
+    AcquisitionListSerializer,
+    AcquisitionWriteSerializer,
+)
+from archive.models import Acquisition
+
+
+class AcquisitionViewSet(ModelViewSet):
+    pagination_class = DefaultCursorPagination
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["source", "rights"]
+
+    def get_queryset(self):
+        return Acquisition.objects.select_related("source").all()
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return AcquisitionListSerializer
+        if self.action == "retrieve":
+            return AcquisitionDetailSerializer
+        return AcquisitionWriteSerializer

--- a/archive/api/viewsets/source.py
+++ b/archive/api/viewsets/source.py
@@ -1,0 +1,21 @@
+from rest_framework.viewsets import ModelViewSet
+
+from archive.api.pagination import DefaultCursorPagination
+from archive.api.serializers.source import (
+    SourceDetailSerializer,
+    SourceListSerializer,
+    SourceWriteSerializer,
+)
+from archive.models import Source
+
+
+class SourceViewSet(ModelViewSet):
+    queryset = Source.objects.all()
+    pagination_class = DefaultCursorPagination
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return SourceListSerializer
+        if self.action == "retrieve":
+            return SourceDetailSerializer
+        return SourceWriteSerializer

--- a/tests/test_source_acquisition_api.py
+++ b/tests/test_source_acquisition_api.py
@@ -1,0 +1,269 @@
+"""Tests for Source and Acquisition serializers and viewsets (TGF-302)."""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from archive.api.serializers.acquisition import (
+    AcquisitionDetailSerializer,
+    AcquisitionListSerializer,
+)
+from archive.api.serializers.source import SourceDetailSerializer, SourceListSerializer
+from archive.models import Acquisition, Source
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def nfl_plus():
+    return Source.objects.create(
+        name="NFL+",
+        source_type="STREAMING",
+        url="https://www.nfl.com/plus/",
+        notes="NFL streaming service",
+    )
+
+
+@pytest.fixture
+def youtube():
+    return Source.objects.create(
+        name="YouTube",
+        source_type="YOUTUBE",
+        url="https://youtube.com",
+    )
+
+
+@pytest.fixture
+def acquisition1(nfl_plus):
+    return Acquisition.objects.create(
+        source=nfl_plus,
+        acquired_on="2024-09-01",
+        cost_usd="14.99",
+        rights="PERSONAL_ONLY",
+        notes="Monthly subscription",
+    )
+
+
+@pytest.fixture
+def acquisition2(youtube):
+    return Acquisition.objects.create(
+        source=youtube,
+        acquired_on="2024-09-15",
+        rights="SHAREABLE",
+    )
+
+
+# --- SourceListSerializer ---
+
+
+@pytest.mark.django_db
+def test_source_list_serializer_fields(nfl_plus):
+    """SourceListSerializer includes id, name, source_type, url."""
+    data = SourceListSerializer(nfl_plus).data
+    assert data["id"] == nfl_plus.pk
+    assert data["name"] == "NFL+"
+    assert data["source_type"] == "STREAMING"
+    assert data["url"] == "https://www.nfl.com/plus/"
+
+
+# --- SourceDetailSerializer ---
+
+
+@pytest.mark.django_db
+def test_source_detail_serializer_all_fields(nfl_plus):
+    """SourceDetailSerializer includes all fields."""
+    data = SourceDetailSerializer(nfl_plus).data
+    assert data["notes"] == "NFL streaming service"
+    assert "bonus_data" in data
+    assert "external_ids" in data
+
+
+# --- AcquisitionListSerializer ---
+
+
+@pytest.mark.django_db
+def test_acquisition_list_serializer_fields(acquisition1, nfl_plus):
+    """AcquisitionListSerializer includes id, source, acquired_on, rights, cost_usd."""
+    acq = Acquisition.objects.select_related("source").get(pk=acquisition1.pk)
+    data = AcquisitionListSerializer(acq).data
+    assert data["id"] == acquisition1.pk
+    assert data["source"] == nfl_plus.pk
+    assert data["acquired_on"] == "2024-09-01"
+    assert data["rights"] == "PERSONAL_ONLY"
+    assert data["cost_usd"] == "14.99"
+
+
+# --- AcquisitionDetailSerializer ---
+
+
+@pytest.mark.django_db
+def test_acquisition_detail_serializer_all_fields(acquisition1):
+    """AcquisitionDetailSerializer includes all fields."""
+    acq = Acquisition.objects.select_related("source").get(pk=acquisition1.pk)
+    data = AcquisitionDetailSerializer(acq).data
+    assert data["notes"] == "Monthly subscription"
+    assert "proof_path" in data
+    assert "bonus_data" in data
+
+
+# --- SourceViewSet: Full CRUD ---
+
+
+@pytest.mark.django_db
+def test_source_list(client, nfl_plus, youtube):
+    """GET /api/v1/sources/ returns sources."""
+    response = client.get("/api/v1/sources/", HTTP_ACCEPT="application/json")
+    assert response.status_code == 200
+    assert "results" in response.json()
+    assert len(response.json()["results"]) == 2
+
+
+@pytest.mark.django_db
+def test_source_retrieve(client, nfl_plus):
+    """GET /api/v1/sources/<id>/ returns detail."""
+    response = client.get(
+        f"/api/v1/sources/{nfl_plus.pk}/", HTTP_ACCEPT="application/json"
+    )
+    assert response.status_code == 200
+    assert response.json()["notes"] == "NFL streaming service"
+
+
+@pytest.mark.django_db
+def test_source_create(client):
+    """POST /api/v1/sources/ creates a source."""
+    response = client.post(
+        "/api/v1/sources/",
+        data={"name": "Paramount+", "source_type": "STREAMING"},
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    assert Source.objects.filter(name="Paramount+").exists()
+
+
+@pytest.mark.django_db
+def test_source_update(client, nfl_plus):
+    """PUT /api/v1/sources/<id>/ updates the source."""
+    response = client.put(
+        f"/api/v1/sources/{nfl_plus.pk}/",
+        data={"name": "NFL+ Premium", "source_type": "STREAMING"},
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    nfl_plus.refresh_from_db()
+    assert nfl_plus.name == "NFL+ Premium"
+
+
+@pytest.mark.django_db
+def test_source_delete(client, nfl_plus):
+    """DELETE /api/v1/sources/<id>/ deletes the source."""
+    response = client.delete(f"/api/v1/sources/{nfl_plus.pk}/")
+    assert response.status_code == 204
+    assert not Source.objects.filter(pk=nfl_plus.pk).exists()
+
+
+# --- AcquisitionViewSet: Full CRUD ---
+
+
+@pytest.mark.django_db
+def test_acquisition_list(client, acquisition1, acquisition2):
+    """GET /api/v1/acquisitions/ returns acquisitions."""
+    response = client.get("/api/v1/acquisitions/", HTTP_ACCEPT="application/json")
+    assert response.status_code == 200
+    assert len(response.json()["results"]) == 2
+
+
+@pytest.mark.django_db
+def test_acquisition_retrieve(client, acquisition1):
+    """GET /api/v1/acquisitions/<id>/ returns detail."""
+    response = client.get(
+        f"/api/v1/acquisitions/{acquisition1.pk}/", HTTP_ACCEPT="application/json"
+    )
+    assert response.status_code == 200
+    assert response.json()["notes"] == "Monthly subscription"
+
+
+@pytest.mark.django_db
+def test_acquisition_create(client, nfl_plus):
+    """POST /api/v1/acquisitions/ creates an acquisition."""
+    response = client.post(
+        "/api/v1/acquisitions/",
+        data={
+            "source": nfl_plus.pk,
+            "acquired_on": "2024-10-01",
+            "rights": "PERSONAL_ONLY",
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 201
+    assert Acquisition.objects.filter(acquired_on="2024-10-01").exists()
+
+
+@pytest.mark.django_db
+def test_acquisition_update(client, acquisition1, nfl_plus):
+    """PUT /api/v1/acquisitions/<id>/ updates the acquisition."""
+    response = client.put(
+        f"/api/v1/acquisitions/{acquisition1.pk}/",
+        data={
+            "source": nfl_plus.pk,
+            "acquired_on": "2024-09-01",
+            "rights": "SHAREABLE",
+        },
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    acquisition1.refresh_from_db()
+    assert acquisition1.rights == "SHAREABLE"
+
+
+@pytest.mark.django_db
+def test_acquisition_delete(client, acquisition1):
+    """DELETE /api/v1/acquisitions/<id>/ deletes the acquisition."""
+    response = client.delete(f"/api/v1/acquisitions/{acquisition1.pk}/")
+    assert response.status_code == 204
+    assert not Acquisition.objects.filter(pk=acquisition1.pk).exists()
+
+
+# --- Acquisition Filters ---
+
+
+@pytest.mark.django_db
+def test_acquisition_filter_by_source(client, acquisition1, acquisition2, nfl_plus):
+    """?source=<id> filters by source."""
+    response = client.get(
+        f"/api/v1/acquisitions/?source={nfl_plus.pk}",
+        HTTP_ACCEPT="application/json",
+    )
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["source"] == nfl_plus.pk
+
+
+@pytest.mark.django_db
+def test_acquisition_filter_by_rights(client, acquisition1, acquisition2):
+    """?rights=SHAREABLE filters by rights."""
+    response = client.get(
+        "/api/v1/acquisitions/?rights=SHAREABLE", HTTP_ACCEPT="application/json"
+    )
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["rights"] == "SHAREABLE"
+
+
+# --- Router registration ---
+
+
+@pytest.mark.django_db
+def test_sources_registered_on_router():
+    """SourceViewSet must be registered at /sources/."""
+    url = reverse("source-list")
+    assert url == "/api/v1/sources/"
+
+
+@pytest.mark.django_db
+def test_acquisitions_registered_on_router():
+    """AcquisitionViewSet must be registered at /acquisitions/."""
+    url = reverse("acquisition-list")
+    assert url == "/api/v1/acquisitions/"


### PR DESCRIPTION
## Summary

- Implement `SourceListSerializer` (id, name, source_type, url), `SourceDetailSerializer` (all fields), `SourceWriteSerializer`
- Implement `AcquisitionListSerializer` (id, source, acquired_on, rights, cost_usd), `AcquisitionDetailSerializer` (all fields), `AcquisitionWriteSerializer`
- `SourceViewSet` supports full CRUD (LIST, CREATE, RETRIEVE, UPDATE, **DELETE**) — first viewset with DELETE support
- `AcquisitionViewSet` supports full CRUD with `DjangoFilterBackend` filters for `source` and `rights`
- `select_related("source")` on Acquisition queryset for N+1 prevention
- Both registered at `/sources/` and `/acquisitions/`
- Add 18 tests covering all acceptance criteria

## Test plan

- [x] All 18 new Source/Acquisition API tests pass
- [x] Full test suite (337 tests) passes with no regressions
- [x] `manage.py check` reports no issues
- [x] `ruff check` and `ruff format` clean

Closes #302