### PR TITLE
feat(GAM #305): add game full-boxscore and summary custom actions

### DIFF
--- a/archive/api/serializers/game_actions.py
+++ b/archive/api/serializers/game_actions.py
@@ -1,0 +1,48 @@
+from rest_framework import serializers
+
+from archive.api.serializers.boxscore import (
+    FumblesBoxscoreSerializer,
+    PassingBoxscoreSerializer,
+    ReceivingBoxscoreSerializer,
+    RushingBoxscoreSerializer,
+    TacklesBoxscoreSerializer,
+)
+from archive.api.serializers.boxscore_special_teams import (
+    ExtraPointsBoxscoreSerializer,
+    FieldGoalsBoxscoreSerializer,
+    KickingBoxscoreSerializer,
+    PuntingBoxscoreSerializer,
+    ReturnBoxscoreSerializer,
+)
+from archive.api.serializers.game import QuarterScoreInlineSerializer
+from archive.api.serializers.team import TeamReferenceSerializer
+
+
+class FullBoxscoreSerializer(serializers.Serializer):
+    passing = PassingBoxscoreSerializer(many=True)
+    rushing = RushingBoxscoreSerializer(many=True)
+    receiving = ReceivingBoxscoreSerializer(many=True)
+    tackles = TacklesBoxscoreSerializer(many=True)
+    fumbles = FumblesBoxscoreSerializer(many=True)
+    field_goals = FieldGoalsBoxscoreSerializer(many=True)
+    extra_points = ExtraPointsBoxscoreSerializer(many=True)
+    kicking = KickingBoxscoreSerializer(many=True)
+    punting = PuntingBoxscoreSerializer(many=True)
+    returns = ReturnBoxscoreSerializer(many=True)
+
+
+class DriveSummarySerializer(serializers.Serializer):
+    total_drives = serializers.IntegerField()
+    scoring_drives = serializers.IntegerField()
+    total_yards = serializers.IntegerField()
+
+
+class GameSummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    date_local = serializers.DateField()
+    home_team = TeamReferenceSerializer()
+    away_team = TeamReferenceSerializer()
+    final_home_score = serializers.IntegerField()
+    final_away_score = serializers.IntegerField()
+    quarter_scores = QuarterScoreInlineSerializer(many=True)
+    drives = DriveSummarySerializer()

--- a/archive/api/viewsets/game.py
+++ b/archive/api/viewsets/game.py
@@ -1,5 +1,6 @@
-from django.db.models import Count
+from django.db.models import Count, Q, Sum
 from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.mixins import (
     CreateModelMixin,
@@ -7,6 +8,7 @@ from rest_framework.mixins import (
     RetrieveModelMixin,
     UpdateModelMixin,
 )
+from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from archive.api.filters import GameFilter
@@ -16,7 +18,23 @@ from archive.api.serializers.game import (
     GameListSerializer,
     GameWriteSerializer,
 )
-from archive.models import Game
+from archive.api.serializers.game_actions import (
+    FullBoxscoreSerializer,
+    GameSummarySerializer,
+)
+from archive.models import (
+    ExtraPointsBoxscore,
+    FieldGoalsBoxscore,
+    FumblesBoxscore,
+    Game,
+    KickingBoxscore,
+    PassingBoxscore,
+    PuntingBoxscore,
+    ReceivingBoxscore,
+    ReturnBoxscore,
+    RushingBoxscore,
+    TacklesBoxscore,
+)
 
 
 class GameViewSet(
@@ -45,4 +63,76 @@ class GameViewSet(
             return GameListSerializer
         if self.action == "retrieve":
             return GameDetailSerializer
+        if self.action == "full_boxscore":
+            return FullBoxscoreSerializer
+        if self.action == "summary":
+            return GameSummarySerializer
         return GameWriteSerializer
+
+    @action(detail=True, methods=["get"], url_path="full-boxscore")
+    def full_boxscore(self, request, pk=None):
+        game = self.get_object()
+        team_select = ["team"]
+        data = {
+            "passing": PassingBoxscore.objects.filter(game=game).select_related(
+                *team_select
+            ),
+            "rushing": RushingBoxscore.objects.filter(game=game).select_related(
+                *team_select
+            ),
+            "receiving": ReceivingBoxscore.objects.filter(game=game).select_related(
+                *team_select
+            ),
+            "tackles": TacklesBoxscore.objects.filter(game=game).select_related(
+                *team_select
+            ),
+            "fumbles": FumblesBoxscore.objects.filter(game=game).select_related(
+                *team_select
+            ),
+            "field_goals": FieldGoalsBoxscore.objects.filter(game=game).select_related(
+                *team_select
+            ),
+            "extra_points": ExtraPointsBoxscore.objects.filter(
+                game=game
+            ).select_related(*team_select),
+            "kicking": KickingBoxscore.objects.filter(game=game).select_related(
+                *team_select
+            ),
+            "punting": PuntingBoxscore.objects.filter(game=game).select_related(
+                *team_select
+            ),
+            "returns": ReturnBoxscore.objects.filter(game=game).select_related(
+                *team_select
+            ),
+        }
+        serializer = FullBoxscoreSerializer(data)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["get"])
+    def summary(self, request, pk=None):
+        game = (
+            Game.objects.select_related("home_team", "away_team")
+            .prefetch_related("quarter_scores", "drives")
+            .get(pk=pk)
+        )
+        drive_agg = game.drives.aggregate(
+            total_drives=Count("id"),
+            scoring_drives=Count("id", filter=Q(ended_with_score=True)),
+            total_yards=Sum("yards_gained"),
+        )
+        data = {
+            "id": game.id,
+            "date_local": game.date_local,
+            "home_team": game.home_team,
+            "away_team": game.away_team,
+            "final_home_score": game.final_home_score,
+            "final_away_score": game.final_away_score,
+            "quarter_scores": game.quarter_scores.all(),
+            "drives": {
+                "total_drives": drive_agg["total_drives"] or 0,
+                "scoring_drives": drive_agg["scoring_drives"] or 0,
+                "total_yards": drive_agg["total_yards"] or 0,
+            },
+        }
+        serializer = GameSummarySerializer(data)
+        return Response(serializer.data)

--- a/tests/test_game_custom_actions.py
+++ b/tests/test_game_custom_actions.py
@@ -1,0 +1,295 @@
+"""Tests for Game full-boxscore and summary custom actions (TGF-305)."""
+
+import pytest
+from django.test import Client
+
+from archive.models import (
+    Drive,
+    Franchise,
+    Game,
+    League,
+    PassingBoxscore,
+    QuarterScore,
+    ReceivingBoxscore,
+    RushingBoxscore,
+    Season,
+    TacklesBoxscore,
+    Team,
+    Venue,
+)
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def nfl():
+    return League.objects.create(
+        short_name="NFL", long_name="National Football League", level="PRO"
+    )
+
+
+@pytest.fixture
+def season_2024(nfl):
+    return Season.objects.create(league=nfl, year=2024, label="2024")
+
+
+@pytest.fixture
+def steelers_franchise(nfl):
+    return Franchise.objects.create(name="Pittsburgh Steelers", league=nfl)
+
+
+@pytest.fixture
+def ravens_franchise(nfl):
+    return Franchise.objects.create(name="Baltimore Ravens", league=nfl)
+
+
+@pytest.fixture
+def steelers(steelers_franchise):
+    return Team.objects.create(
+        franchise=steelers_franchise,
+        name="Pittsburgh Steelers",
+        short_name="PIT",
+        city="Pittsburgh",
+    )
+
+
+@pytest.fixture
+def ravens(ravens_franchise):
+    return Team.objects.create(
+        franchise=ravens_franchise,
+        name="Baltimore Ravens",
+        short_name="BAL",
+        city="Baltimore",
+    )
+
+
+@pytest.fixture
+def heinz_field():
+    return Venue.objects.create(
+        name="Heinz Field", city="Pittsburgh", state="PA", capacity=68400
+    )
+
+
+@pytest.fixture
+def game(nfl, season_2024, steelers, ravens, heinz_field):
+    return Game.objects.create(
+        league=nfl,
+        season=season_2024,
+        date_local="2024-09-08",
+        week=1,
+        home_team=steelers,
+        away_team=ravens,
+        venue=heinz_field,
+        final_home_score=24,
+        final_away_score=17,
+    )
+
+
+@pytest.fixture
+def passing_stat(game, steelers):
+    return PassingBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="Kenny Pickett",
+        position="QB",
+        attempts=30,
+        completions=20,
+        yards=250,
+    )
+
+
+@pytest.fixture
+def rushing_stat(game, steelers):
+    return RushingBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="Najee Harris",
+        position="RB",
+        attempts=18,
+        yards=85,
+    )
+
+
+@pytest.fixture
+def receiving_stat(game, steelers):
+    return ReceivingBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="George Pickens",
+        position="WR",
+        receptions=6,
+        yards=110,
+    )
+
+
+@pytest.fixture
+def tackles_stat(game, steelers):
+    return TacklesBoxscore.objects.create(
+        game=game,
+        team=steelers,
+        side="home",
+        player_name="T.J. Watt",
+        position="OLB",
+        tackles=6,
+    )
+
+
+@pytest.fixture
+def quarter_scores(game, steelers, ravens):
+    return [
+        QuarterScore.objects.create(game=game, team=steelers, period=1, points=7),
+        QuarterScore.objects.create(game=game, team=steelers, period=2, points=10),
+        QuarterScore.objects.create(game=game, team=ravens, period=1, points=3),
+        QuarterScore.objects.create(game=game, team=ravens, period=2, points=7),
+    ]
+
+
+@pytest.fixture
+def drives(game, steelers, ravens):
+    return [
+        Drive.objects.create(
+            game=game,
+            sequence=1,
+            team=steelers,
+            yards_gained=75,
+            ended_with_score=True,
+        ),
+        Drive.objects.create(
+            game=game,
+            sequence=2,
+            team=ravens,
+            yards_gained=45,
+            ended_with_score=False,
+        ),
+        Drive.objects.create(
+            game=game,
+            sequence=3,
+            team=steelers,
+            yards_gained=60,
+            ended_with_score=True,
+        ),
+    ]
+
+
+# --- full-boxscore action ---
+
+
+@pytest.mark.django_db
+def test_full_boxscore_returns_200(client, game):
+    """GET /api/v1/games/<id>/full-boxscore/ returns 200."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/full-boxscore/", HTTP_ACCEPT="application/json"
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_full_boxscore_has_all_10_categories(client, game):
+    """Response contains all 10 boxscore category keys."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/full-boxscore/", HTTP_ACCEPT="application/json"
+    )
+    data = response.json()
+    expected_keys = {
+        "passing",
+        "rushing",
+        "receiving",
+        "tackles",
+        "fumbles",
+        "field_goals",
+        "extra_points",
+        "kicking",
+        "punting",
+        "returns",
+    }
+    assert set(data.keys()) == expected_keys
+
+
+@pytest.mark.django_db
+def test_full_boxscore_includes_stats(
+    client, game, passing_stat, rushing_stat, receiving_stat, tackles_stat
+):
+    """Boxscore categories contain the correct stats."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/full-boxscore/", HTTP_ACCEPT="application/json"
+    )
+    data = response.json()
+    assert len(data["passing"]) == 1
+    assert data["passing"][0]["player_name"] == "Kenny Pickett"
+    assert len(data["rushing"]) == 1
+    assert len(data["receiving"]) == 1
+    assert len(data["tackles"]) == 1
+    assert len(data["fumbles"]) == 0  # no fumble stats created
+
+
+@pytest.mark.django_db
+def test_full_boxscore_empty_game(client, game):
+    """Full boxscore for game with no stats returns empty arrays."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/full-boxscore/", HTTP_ACCEPT="application/json"
+    )
+    data = response.json()
+    for category in data.values():
+        assert category == []
+
+
+# --- summary action ---
+
+
+@pytest.mark.django_db
+def test_summary_returns_200(client, game):
+    """GET /api/v1/games/<id>/summary/ returns 200."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/summary/", HTTP_ACCEPT="application/json"
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_summary_includes_team_names(client, game):
+    """Summary includes home_team and away_team references."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/summary/", HTTP_ACCEPT="application/json"
+    )
+    data = response.json()
+    assert data["home_team"]["short_name"] == "PIT"
+    assert data["away_team"]["short_name"] == "BAL"
+
+
+@pytest.mark.django_db
+def test_summary_includes_scores(client, game):
+    """Summary includes final scores."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/summary/", HTTP_ACCEPT="application/json"
+    )
+    data = response.json()
+    assert data["final_home_score"] == 24
+    assert data["final_away_score"] == 17
+
+
+@pytest.mark.django_db
+def test_summary_includes_quarter_scores(client, game, quarter_scores):
+    """Summary includes quarter scores."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/summary/", HTTP_ACCEPT="application/json"
+    )
+    data = response.json()
+    assert len(data["quarter_scores"]) == 4
+
+
+@pytest.mark.django_db
+def test_summary_includes_drive_summary(client, game, drives):
+    """Summary includes drive summary with total count, scoring count, and total yards."""
+    response = client.get(
+        f"/api/v1/games/{game.pk}/summary/", HTTP_ACCEPT="application/json"
+    )
+    data = response.json()
+    assert data["drives"]["total_drives"] == 3
+    assert data["drives"]["scoring_drives"] == 2
+    assert data["drives"]["total_yards"] == 180  # 75 + 45 + 60


### PR DESCRIPTION
## Summary

- Implement `GET /games/{id}/full-boxscore/` — returns all 10 boxscore categories in a single JSON response keyed by stat type (passing, rushing, receiving, tackles, fumbles, field_goals, extra_points, kicking, punting, returns)
- Implement `FullBoxscoreSerializer` as a composite `serializers.Serializer` delegating to existing boxscore serializers
- Implement `GET /games/{id}/summary/` — returns game info with team names, quarter scores, final scores, and drive summary (total drives, scoring drives, total yards)
- Implement `GameSummarySerializer` with nested `TeamReferenceSerializer`, `QuarterScoreInlineSerializer`, and `DriveSummarySerializer`
- Both use `@action(detail=True, methods=["get"])` on GameViewSet
- Both use optimized querysets with `select_related` to minimize DB queries
- Add 9 tests covering all acceptance criteria

## Test plan

- [x] All 9 new game custom actions tests pass
- [x] Full test suite (379 tests) passes with no regressions
- [x] `manage.py check` reports no issues
- [x] `ruff check` and `ruff format` clean

Closes #305