### PR TITLE
feat(GAM #306): add team schedule and current-venue custom actions

### DIFF
--- a/archive/api/viewsets/team.py
+++ b/archive/api/viewsets/team.py
@@ -1,4 +1,6 @@
+from django.db.models import Q
 from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.decorators import action
 from rest_framework.filters import SearchFilter
 from rest_framework.mixins import (
     CreateModelMixin,
@@ -6,15 +8,18 @@ from rest_framework.mixins import (
     RetrieveModelMixin,
     UpdateModelMixin,
 )
+from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from archive.api.pagination import DefaultCursorPagination
+from archive.api.serializers.game import GameListSerializer
 from archive.api.serializers.team import (
     TeamDetailSerializer,
     TeamListSerializer,
     TeamWriteSerializer,
 )
-from archive.models import Team
+from archive.api.serializers.venue import VenueDetailSerializer
+from archive.models import Game, Team, TeamVenueOccupancy
 
 
 class TeamViewSet(
@@ -41,4 +46,44 @@ class TeamViewSet(
             return TeamListSerializer
         if self.action == "retrieve":
             return TeamDetailSerializer
+        if self.action == "schedule":
+            return GameListSerializer
+        if self.action == "current_venue":
+            return VenueDetailSerializer
         return TeamWriteSerializer
+
+    @action(detail=True, methods=["get"])
+    def schedule(self, request, pk=None):
+        team = self.get_object()
+        season_year = request.query_params.get("season_year")
+        if not season_year:
+            return Response(
+                {"detail": "season_year query parameter is required."}, status=400
+            )
+        games = (
+            Game.objects.filter(
+                Q(home_team=team) | Q(away_team=team),
+                season__year=int(season_year),
+            )
+            .select_related("home_team", "away_team", "venue")
+            .order_by("date_local")
+        )
+        serializer = GameListSerializer(games, many=True)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["get"], url_path="current-venue")
+    def current_venue(self, request, pk=None):
+        team = self.get_object()
+        occupancy = (
+            TeamVenueOccupancy.objects.filter(team=team)
+            .filter(Q(end_date__isnull=True) | Q(end_date__gte="2020-01-01"))
+            .select_related("venue")
+            .order_by("-start_date")
+            .first()
+        )
+        if not occupancy:
+            return Response(
+                {"detail": "No venue occupancy found for this team."}, status=404
+            )
+        serializer = VenueDetailSerializer(occupancy.venue)
+        return Response(serializer.data)

--- a/tests/test_team_custom_actions.py
+++ b/tests/test_team_custom_actions.py
@@ -1,0 +1,273 @@
+"""Tests for Team schedule and current-venue custom actions (TGF-306)."""
+
+import pytest
+from django.test import Client
+
+from archive.models import (
+    Franchise,
+    Game,
+    League,
+    Season,
+    Team,
+    TeamVenueOccupancy,
+    Venue,
+)
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+@pytest.fixture
+def nfl():
+    return League.objects.create(
+        short_name="NFL", long_name="National Football League", level="PRO"
+    )
+
+
+@pytest.fixture
+def season_2024(nfl):
+    return Season.objects.create(league=nfl, year=2024, label="2024")
+
+
+@pytest.fixture
+def season_2025(nfl):
+    return Season.objects.create(league=nfl, year=2025, label="2025")
+
+
+@pytest.fixture
+def steelers_franchise(nfl):
+    return Franchise.objects.create(name="Pittsburgh Steelers", league=nfl)
+
+
+@pytest.fixture
+def ravens_franchise(nfl):
+    return Franchise.objects.create(name="Baltimore Ravens", league=nfl)
+
+
+@pytest.fixture
+def bengals_franchise(nfl):
+    return Franchise.objects.create(name="Cincinnati Bengals", league=nfl)
+
+
+@pytest.fixture
+def steelers(steelers_franchise):
+    return Team.objects.create(
+        franchise=steelers_franchise,
+        name="Pittsburgh Steelers",
+        short_name="PIT",
+        city="Pittsburgh",
+    )
+
+
+@pytest.fixture
+def ravens(ravens_franchise):
+    return Team.objects.create(
+        franchise=ravens_franchise,
+        name="Baltimore Ravens",
+        short_name="BAL",
+        city="Baltimore",
+    )
+
+
+@pytest.fixture
+def bengals(bengals_franchise):
+    return Team.objects.create(
+        franchise=bengals_franchise,
+        name="Cincinnati Bengals",
+        short_name="CIN",
+        city="Cincinnati",
+    )
+
+
+@pytest.fixture
+def heinz_field():
+    return Venue.objects.create(
+        name="Heinz Field", city="Pittsburgh", state="PA", capacity=68400
+    )
+
+
+@pytest.fixture
+def acrisure():
+    return Venue.objects.create(
+        name="Acrisure Stadium", city="Pittsburgh", state="PA", capacity=68400
+    )
+
+
+@pytest.fixture
+def game_home(nfl, season_2024, steelers, ravens, heinz_field):
+    return Game.objects.create(
+        league=nfl,
+        season=season_2024,
+        date_local="2024-09-08",
+        week=1,
+        home_team=steelers,
+        away_team=ravens,
+        venue=heinz_field,
+    )
+
+
+@pytest.fixture
+def game_away(nfl, season_2024, bengals, steelers, heinz_field):
+    return Game.objects.create(
+        league=nfl,
+        season=season_2024,
+        date_local="2024-09-15",
+        week=2,
+        home_team=bengals,
+        away_team=steelers,
+        venue=heinz_field,
+    )
+
+
+@pytest.fixture
+def game_other_season(nfl, season_2025, steelers, ravens, heinz_field):
+    return Game.objects.create(
+        league=nfl,
+        season=season_2025,
+        date_local="2025-09-07",
+        week=1,
+        home_team=steelers,
+        away_team=ravens,
+        venue=heinz_field,
+    )
+
+
+@pytest.fixture
+def old_occupancy(steelers, heinz_field):
+    return TeamVenueOccupancy.objects.create(
+        team=steelers,
+        venue=heinz_field,
+        start_date="2001-08-18",
+        end_date="2022-03-01",
+    )
+
+
+@pytest.fixture
+def current_occupancy(steelers, acrisure):
+    return TeamVenueOccupancy.objects.create(
+        team=steelers,
+        venue=acrisure,
+        start_date="2022-03-01",
+    )
+
+
+# --- schedule action ---
+
+
+@pytest.mark.django_db
+def test_schedule_returns_200(client, steelers, game_home):
+    """GET /api/v1/teams/<id>/schedule/?season_year=2024 returns 200."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/schedule/?season_year=2024",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_schedule_includes_home_and_away(client, steelers, game_home, game_away):
+    """Schedule includes games where team is both home and away."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/schedule/?season_year=2024",
+        HTTP_ACCEPT="application/json",
+    )
+    data = response.json()
+    assert len(data) == 2
+
+
+@pytest.mark.django_db
+def test_schedule_ordered_by_date(client, steelers, game_home, game_away):
+    """Schedule is ordered by date_local ascending."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/schedule/?season_year=2024",
+        HTTP_ACCEPT="application/json",
+    )
+    data = response.json()
+    assert data[0]["date_local"] == "2024-09-08"
+    assert data[1]["date_local"] == "2024-09-15"
+
+
+@pytest.mark.django_db
+def test_schedule_filters_by_season(client, steelers, game_home, game_other_season):
+    """Schedule only returns games from the specified season."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/schedule/?season_year=2024",
+        HTTP_ACCEPT="application/json",
+    )
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["date_local"] == "2024-09-08"
+
+
+@pytest.mark.django_db
+def test_schedule_requires_season_year(client, steelers):
+    """Returns 400 if season_year parameter is missing."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/schedule/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 400
+    assert "season_year" in response.json()["detail"]
+
+
+@pytest.mark.django_db
+def test_schedule_empty_season(client, steelers, season_2025):
+    """Returns empty list for season with no games."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/schedule/?season_year=2025",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+# --- current-venue action ---
+
+
+@pytest.mark.django_db
+def test_current_venue_returns_200(client, steelers, current_occupancy):
+    """GET /api/v1/teams/<id>/current-venue/ returns 200."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/current-venue/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_current_venue_returns_most_recent(
+    client, steelers, old_occupancy, current_occupancy
+):
+    """Returns the most recent venue (by start_date), not the old one."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/current-venue/",
+        HTTP_ACCEPT="application/json",
+    )
+    data = response.json()
+    assert data["name"] == "Acrisure Stadium"
+
+
+@pytest.mark.django_db
+def test_current_venue_includes_detail_fields(client, steelers, current_occupancy):
+    """Response includes full venue detail fields."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/current-venue/",
+        HTTP_ACCEPT="application/json",
+    )
+    data = response.json()
+    assert "city" in data
+    assert "state" in data
+    assert "country" in data
+    assert "capacity" in data
+
+
+@pytest.mark.django_db
+def test_current_venue_404_if_no_occupancy(client, steelers):
+    """Returns 404 if no venue occupancy exists for the team."""
+    response = client.get(
+        f"/api/v1/teams/{steelers.pk}/current-venue/",
+        HTTP_ACCEPT="application/json",
+    )
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Implement `GET /teams/{id}/schedule/?season_year=2025` — returns all games where the team is home or away in the given season, ordered by date_local ascending
- `season_year` query parameter is required; returns 400 with message if missing
- Implement `GET /teams/{id}/current-venue/` — returns the team's current home venue based on the most recent `TeamVenueOccupancy` record (by start_date, filtered to open or recent end_date)
- Returns 404 with message if no venue occupancy exists
- Both use `@action(detail=True, methods=["get"])` on `TeamViewSet`
- Both use `select_related` for optimized queries
- Add 10 tests covering all acceptance criteria

## Test plan

- [x] All 10 new team custom actions tests pass
- [x] Full test suite (389 tests) passes with no regressions
- [x] `manage.py check` reports no issues
- [x] `ruff check` and `ruff format` clean

Closes #306