### PR TITLE
feat(GAM #313): add JWKS-based JWT authentication for DRF

### DIFF
--- a/gam/auth/__init__.py
+++ b/gam/auth/__init__.py
@@ -1,0 +1,3 @@
+from gam.auth.jwt import JWKSAuthentication, JWTPrincipal
+
+__all__ = ["JWKSAuthentication", "JWTPrincipal"]

--- a/gam/auth/jwt.py
+++ b/gam/auth/jwt.py
@@ -1,0 +1,147 @@
+"""
+JWKS-based JWT authentication for DRF.
+
+Validates bearer JWTs against a configurable JWKS endpoint. IdP-agnostic: the
+same class works against Clerk, Auth0, or any JWKS-based IdP — only the
+``JWKS_URL``, ``JWT_AUDIENCE``, and ``JWT_ISSUER`` settings change.
+
+Returns a lightweight :class:`JWTPrincipal` (not a Django ``User``) to avoid a
+DB hit per request. User sync is a separate concern handled downstream.
+
+JWKS key caching is delegated to ``PyJWKClient`` — it caches fetched keys in
+process memory and refreshes on cache miss, which is sufficient for current
+throughput. Revisit if token-issuer rotates keys more aggressively than the
+client refresh cadence tolerates.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any
+
+import jwt
+from django.conf import settings
+from jwt import PyJWKClient
+from rest_framework import authentication, exceptions
+
+ALLOWED_ALGORITHMS = ["RS256"]
+
+
+@dataclass(frozen=True)
+class JWTPrincipal:
+    """Lightweight request principal derived from validated JWT claims.
+
+    Mimics the small surface of ``django.contrib.auth`` that DRF and views
+    actually read (``is_authenticated``, ``is_anonymous``) without requiring a
+    database-backed user row. The raw claims are preserved on ``claims`` for
+    downstream authorization logic.
+    """
+
+    claims: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def is_authenticated(self) -> bool:
+        return True
+
+    @property
+    def is_anonymous(self) -> bool:
+        return False
+
+    @property
+    def subject(self) -> str | None:
+        return self.claims.get("sub")
+
+    def __str__(self) -> str:
+        return self.subject or "JWTPrincipal"
+
+
+@lru_cache(maxsize=1)
+def _get_jwks_client() -> PyJWKClient:
+    """Return a process-wide ``PyJWKClient`` bound to ``settings.JWKS_URL``.
+
+    Cached so we don't rebuild the signing-key cache on every request.
+    """
+    jwks_url = getattr(settings, "JWKS_URL", None)
+    if not jwks_url:
+        raise exceptions.AuthenticationFailed(
+            "JWKS_URL is not configured; cannot verify tokens."
+        )
+    return PyJWKClient(jwks_url)
+
+
+class JWKSAuthentication(authentication.BaseAuthentication):
+    """Authenticate requests via bearer JWTs verified against a JWKS endpoint.
+
+    Returns ``None`` when no ``Authorization: Bearer <token>`` header is
+    present so other authentication classes (or anonymous access) can still
+    apply. Raises :class:`rest_framework.exceptions.AuthenticationFailed` on
+    any token that is present but invalid.
+    """
+
+    keyword = "Bearer"
+
+    def authenticate(self, request: Any) -> tuple[JWTPrincipal, dict[str, Any]] | None:
+        token = self._extract_bearer_token(request)
+        if token is None:
+            return None
+
+        claims = self._decode_token(token)
+        return (JWTPrincipal(claims=claims), claims)
+
+    def authenticate_header(self, request: Any) -> str:
+        return self.keyword
+
+    def _extract_bearer_token(self, request: Any) -> str | None:
+        header = request.META.get("HTTP_AUTHORIZATION", "")
+        if not header:
+            return None
+
+        parts = header.split()
+        if parts[0] != self.keyword:
+            return None
+        if len(parts) == 1:
+            raise exceptions.AuthenticationFailed(
+                "Invalid Authorization header: no credentials provided."
+            )
+        if len(parts) > 2:
+            raise exceptions.AuthenticationFailed(
+                "Invalid Authorization header: token must not contain spaces."
+            )
+        return parts[1]
+
+    def _decode_token(self, token: str) -> dict[str, Any]:
+        audience = getattr(settings, "JWT_AUDIENCE", None)
+        issuer = getattr(settings, "JWT_ISSUER", None)
+        if not audience or not issuer:
+            raise exceptions.AuthenticationFailed(
+                "JWT_AUDIENCE and JWT_ISSUER must be configured."
+            )
+
+        try:
+            signing_key = _get_jwks_client().get_signing_key_from_jwt(token).key
+            return jwt.decode(
+                token,
+                signing_key,
+                algorithms=ALLOWED_ALGORITHMS,
+                audience=audience,
+                issuer=issuer,
+            )
+        except jwt.ExpiredSignatureError as exc:
+            raise exceptions.AuthenticationFailed("Token has expired.") from exc
+        except jwt.InvalidAudienceError as exc:
+            raise exceptions.AuthenticationFailed("Invalid audience.") from exc
+        except jwt.InvalidIssuerError as exc:
+            raise exceptions.AuthenticationFailed("Invalid issuer.") from exc
+        except jwt.InvalidAlgorithmError as exc:
+            raise exceptions.AuthenticationFailed("Invalid signing algorithm.") from exc
+        except jwt.InvalidSignatureError as exc:
+            raise exceptions.AuthenticationFailed("Invalid signature.") from exc
+        except jwt.DecodeError as exc:
+            raise exceptions.AuthenticationFailed(f"Invalid token: {exc}") from exc
+        except jwt.PyJWKClientError as exc:
+            raise exceptions.AuthenticationFailed(
+                f"Unable to resolve signing key: {exc}"
+            ) from exc
+        except jwt.PyJWTError as exc:
+            raise exceptions.AuthenticationFailed(f"Invalid token: {exc}") from exc

--- a/gam/settings.py
+++ b/gam/settings.py
@@ -131,6 +131,11 @@ MEDIA_ROOT = os.getenv("MEDIA_ROOT")
 GRIDDY_NFL_EMAIL = os.getenv("GRIDDY_NFL_EMAIL")
 GRIDDY_NFL_PASSWORD = os.getenv("GRIDDY_NFL_PASSWORD")
 
+# JWT / JWKS authentication — IdP-agnostic (works with Clerk, Auth0, etc.)
+JWKS_URL = os.getenv("JWKS_URL")
+JWT_AUDIENCE = os.getenv("JWT_AUDIENCE")
+JWT_ISSUER = os.getenv("JWT_ISSUER")
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/6.0/ref/settings/#default-auto-field
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "griddy>=0.45.0,<1.0",
     "pillow>=12.1.0",
     "psycopg>=3.3.2",
+    "pyjwt[crypto]>=2.10.0",
     "pytest-cov>=7.0.0",
     "requests>=2.32.5",
 ]

--- a/scripts/local_jwks_server.py
+++ b/scripts/local_jwks_server.py
@@ -1,0 +1,176 @@
+"""
+Local JWKS server + test-token issuer for exercising :class:`JWKSAuthentication`
+end-to-end without depending on a real IdP (Clerk, Auth0, etc.).
+
+Usage::
+
+    # Terminal 1 — start the server and emit a signed token:
+    python scripts/local_jwks_server.py --issue
+
+    # Terminal 2 — point the Django app at it and hit any endpoint:
+    export JWKS_URL=http://127.0.0.1:8765/.well-known/jwks.json
+    export JWT_ISSUER=https://local.griddy.test
+    export JWT_AUDIENCE=griddy-api-local
+    curl -H "Authorization: Bearer <token-from-terminal-1>" \\
+         http://127.0.0.1:8000/api/v1/leagues/
+
+The keypair is regenerated on every server start, so tokens do not survive a
+restart. That is intentional — this script is a dev aid, not a persistent IdP.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import threading
+import time
+from datetime import UTC, datetime, timedelta
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from jwt.utils import to_base64url_uint
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8765
+DEFAULT_ISSUER = "https://local.griddy.test"
+DEFAULT_AUDIENCE = "griddy-api-local"
+DEFAULT_KID = "local-dev-key-1"
+
+
+def _build_jwks(public_key: rsa.RSAPublicKey, kid: str) -> dict[str, Any]:
+    numbers = public_key.public_numbers()
+    return {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "alg": "RS256",
+                "kid": kid,
+                "n": to_base64url_uint(numbers.n).decode("ascii"),
+                "e": to_base64url_uint(numbers.e).decode("ascii"),
+            }
+        ]
+    }
+
+
+def _issue_token(
+    private_key: rsa.RSAPrivateKey,
+    *,
+    kid: str,
+    issuer: str,
+    audience: str,
+    subject: str,
+    ttl_seconds: int,
+    extra_claims: dict[str, Any] | None = None,
+) -> str:
+    now = datetime.now(UTC)
+    claims: dict[str, Any] = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": subject,
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(seconds=ttl_seconds)).timestamp()),
+    }
+    if extra_claims:
+        claims.update(extra_claims)
+
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return jwt.encode(claims, pem, algorithm="RS256", headers={"kid": kid})
+
+
+def _make_handler(jwks: dict[str, Any]) -> type[BaseHTTPRequestHandler]:
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path != "/.well-known/jwks.json":
+                self.send_response(404)
+                self.end_headers()
+                return
+            payload = json.dumps(jwks).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, format: str, *args: Any) -> None:
+            sys.stderr.write(
+                f"[jwks-server] {self.address_string()} - {format % args}\n"
+            )
+
+    return Handler
+
+
+def serve(
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    *,
+    private_key: rsa.RSAPrivateKey | None = None,
+    kid: str = DEFAULT_KID,
+) -> tuple[HTTPServer, rsa.RSAPrivateKey]:
+    """Start an HTTP server hosting a JWKS derived from ``private_key``.
+
+    Returns the server and the private key. Call ``server.shutdown()`` to
+    stop it. Intended for both CLI use and in-process test harnesses.
+    """
+    if private_key is None:
+        private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    jwks = _build_jwks(private_key.public_key(), kid)
+    server = HTTPServer((host, port), _make_handler(jwks))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, private_key
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument("--issuer", default=DEFAULT_ISSUER)
+    parser.add_argument("--audience", default=DEFAULT_AUDIENCE)
+    parser.add_argument("--kid", default=DEFAULT_KID)
+    parser.add_argument("--subject", default="user_local_dev")
+    parser.add_argument("--ttl", type=int, default=3600, help="Token TTL in seconds.")
+    parser.add_argument(
+        "--issue",
+        action="store_true",
+        help="Print a signed token on startup and keep serving.",
+    )
+    args = parser.parse_args(argv)
+
+    server, private_key = serve(args.host, args.port, kid=args.kid)
+    sys.stderr.write(
+        f"[jwks-server] serving JWKS at http://{args.host}:{args.port}"
+        f"/.well-known/jwks.json\n"
+    )
+
+    if args.issue:
+        token = _issue_token(
+            private_key,
+            kid=args.kid,
+            issuer=args.issuer,
+            audience=args.audience,
+            subject=args.subject,
+            ttl_seconds=args.ttl,
+        )
+        sys.stdout.write(token + "\n")
+        sys.stdout.flush()
+
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        sys.stderr.write("[jwks-server] shutting down\n")
+        server.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_jwks_auth.py
+++ b/tests/test_jwks_auth.py
@@ -1,0 +1,418 @@
+"""
+Unit tests for :class:`gam.auth.jwt.JWKSAuthentication` (TGF-313).
+
+Covers header parsing, signing-algorithm rejection, audience/issuer/expiry
+validation, and the structure of the returned principal. Tests mock
+``PyJWKClient.get_signing_key_from_jwt`` so signature verification runs
+against a local RSA keypair — no network calls or real IdP required.
+
+The :class:`TestLocalJWKSHarness` class exercises the dev-harness script
+end-to-end (real HTTP, real PyJWKClient fetch) to prove that the same
+authentication class works against a JWKS endpoint it has never seen before.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from django.test import override_settings
+from rest_framework import exceptions
+from rest_framework.test import APIRequestFactory
+
+from gam.auth.jwt import JWKSAuthentication, JWTPrincipal, _get_jwks_client
+
+TEST_ISSUER = "https://issuer.test.griddy"
+TEST_AUDIENCE = "griddy-api-test"
+TEST_KID = "test-kid"
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="module")
+def other_keypair() -> rsa.RSAPrivateKey:
+    """Second keypair used to simulate mismatched-signature scenarios."""
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(autouse=True)
+def clear_jwks_client_cache():
+    """Ensure each test gets a fresh :func:`_get_jwks_client` cache."""
+    _get_jwks_client.cache_clear()
+    yield
+    _get_jwks_client.cache_clear()
+
+
+@pytest.fixture
+def configured_settings():
+    with override_settings(
+        JWKS_URL="http://example.test/.well-known/jwks.json",
+        JWT_AUDIENCE=TEST_AUDIENCE,
+        JWT_ISSUER=TEST_ISSUER,
+    ):
+        yield
+
+
+@pytest.fixture
+def factory() -> APIRequestFactory:
+    return APIRequestFactory()
+
+
+def _encode(
+    private_key: rsa.RSAPrivateKey,
+    *,
+    algorithm: str = "RS256",
+    audience: str = TEST_AUDIENCE,
+    issuer: str = TEST_ISSUER,
+    expires_in: int = 3600,
+    extra_claims: dict[str, Any] | None = None,
+    headers: dict[str, Any] | None = None,
+    key_override: Any = None,
+) -> str:
+    now = datetime.now(UTC)
+    claims: dict[str, Any] = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": "user_123",
+        "iat": int(now.timestamp()),
+        "exp": int((now + timedelta(seconds=expires_in)).timestamp()),
+    }
+    if extra_claims:
+        claims.update(extra_claims)
+    signing_material = key_override if key_override is not None else private_key
+    return jwt.encode(
+        claims,
+        signing_material,
+        algorithm=algorithm,
+        headers={"kid": TEST_KID, **(headers or {})},
+    )
+
+
+def _patch_signing_key(public_key: Any):
+    """Patch PyJWKClient.get_signing_key_from_jwt to return ``public_key``."""
+    mock_signing = MagicMock()
+    mock_signing.key = public_key
+    return patch(
+        "gam.auth.jwt.PyJWKClient.get_signing_key_from_jwt",
+        return_value=mock_signing,
+    )
+
+
+# ---------------------------------------------------------------------------
+# JWTPrincipal
+# ---------------------------------------------------------------------------
+
+
+class TestJWTPrincipal:
+    def test_is_authenticated_is_true(self):
+        principal = JWTPrincipal(claims={"sub": "u1"})
+        assert principal.is_authenticated is True
+
+    def test_is_anonymous_is_false(self):
+        principal = JWTPrincipal(claims={"sub": "u1"})
+        assert principal.is_anonymous is False
+
+    def test_subject_reads_sub_claim(self):
+        principal = JWTPrincipal(claims={"sub": "user_42"})
+        assert principal.subject == "user_42"
+
+    def test_subject_is_none_when_missing(self):
+        principal = JWTPrincipal(claims={})
+        assert principal.subject is None
+
+    def test_claims_are_preserved(self):
+        claims = {"sub": "u1", "email": "user@griddy.test", "roles": ["admin"]}
+        principal = JWTPrincipal(claims=claims)
+        assert principal.claims == claims
+
+    def test_principal_is_immutable(self):
+        principal = JWTPrincipal(claims={"sub": "u1"})
+        with pytest.raises(FrozenInstanceError):
+            principal.claims = {}  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Header parsing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("configured_settings")
+class TestHeaderParsing:
+    def test_missing_header_returns_none(self, factory):
+        request = factory.get("/api/v1/leagues/")
+        assert JWKSAuthentication().authenticate(request) is None
+
+    def test_non_bearer_scheme_returns_none(self, factory):
+        request = factory.get("/", HTTP_AUTHORIZATION="Basic dXNlcjpwdw==")
+        assert JWKSAuthentication().authenticate(request) is None
+
+    def test_bearer_without_token_raises(self, factory):
+        request = factory.get("/", HTTP_AUTHORIZATION="Bearer")
+        with pytest.raises(exceptions.AuthenticationFailed):
+            JWKSAuthentication().authenticate(request)
+
+    def test_bearer_with_extra_parts_raises(self, factory):
+        request = factory.get("/", HTTP_AUTHORIZATION="Bearer a b c")
+        with pytest.raises(exceptions.AuthenticationFailed):
+            JWKSAuthentication().authenticate(request)
+
+    def test_authenticate_header_advertises_bearer(self, factory):
+        request = factory.get("/")
+        assert JWKSAuthentication().authenticate_header(request) == "Bearer"
+
+
+# ---------------------------------------------------------------------------
+# Successful decode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("configured_settings")
+class TestValidToken:
+    def test_returns_principal_and_claims(self, factory, rsa_keypair):
+        token = _encode(rsa_keypair)
+        public_key = rsa_keypair.public_key()
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        with _patch_signing_key(public_key):
+            principal, auth = JWKSAuthentication().authenticate(request)
+
+        assert isinstance(principal, JWTPrincipal)
+        assert principal.subject == "user_123"
+        assert auth["iss"] == TEST_ISSUER
+        assert auth["aud"] == TEST_AUDIENCE
+
+    def test_extra_claims_preserved_on_principal(self, factory, rsa_keypair):
+        token = _encode(
+            rsa_keypair,
+            extra_claims={"email": "user@griddy.test", "role": "admin"},
+        )
+        public_key = rsa_keypair.public_key()
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        with _patch_signing_key(public_key):
+            principal, _ = JWKSAuthentication().authenticate(request)
+
+        assert principal.claims["email"] == "user@griddy.test"
+        assert principal.claims["role"] == "admin"
+
+
+# ---------------------------------------------------------------------------
+# Invalid tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("configured_settings")
+class TestInvalidTokens:
+    def test_expired_token_rejected(self, factory, rsa_keypair):
+        token = _encode(rsa_keypair, expires_in=-60)
+        public_key = rsa_keypair.public_key()
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        with (
+            _patch_signing_key(public_key),
+            pytest.raises(exceptions.AuthenticationFailed, match="expired"),
+        ):
+            JWKSAuthentication().authenticate(request)
+
+    def test_wrong_audience_rejected(self, factory, rsa_keypair):
+        token = _encode(rsa_keypair, audience="some-other-api")
+        public_key = rsa_keypair.public_key()
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        with (
+            _patch_signing_key(public_key),
+            pytest.raises(exceptions.AuthenticationFailed, match="audience"),
+        ):
+            JWKSAuthentication().authenticate(request)
+
+    def test_wrong_issuer_rejected(self, factory, rsa_keypair):
+        token = _encode(rsa_keypair, issuer="https://evil.example")
+        public_key = rsa_keypair.public_key()
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        with (
+            _patch_signing_key(public_key),
+            pytest.raises(exceptions.AuthenticationFailed, match="issuer"),
+        ):
+            JWKSAuthentication().authenticate(request)
+
+    def test_signed_by_different_key_rejected(
+        self, factory, rsa_keypair, other_keypair
+    ):
+        """Token signed by an attacker's key must not verify against the JWKS key."""
+        token = _encode(other_keypair)  # signed by wrong key
+        public_key = rsa_keypair.public_key()  # JWKS returns the right key
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        with (
+            _patch_signing_key(public_key),
+            pytest.raises(exceptions.AuthenticationFailed, match="signature"),
+        ):
+            JWKSAuthentication().authenticate(request)
+
+    def test_malformed_token_rejected(self, factory, rsa_keypair):
+        request = factory.get("/", HTTP_AUTHORIZATION="Bearer not-a-real-jwt")
+
+        with (
+            _patch_signing_key(rsa_keypair.public_key()),
+            pytest.raises(exceptions.AuthenticationFailed),
+        ):
+            JWKSAuthentication().authenticate(request)
+
+
+# ---------------------------------------------------------------------------
+# Signing-algorithm enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("configured_settings")
+class TestAlgorithmEnforcement:
+    def test_alg_none_rejected(self, factory):
+        # "alg: none" unsigned token — the classic downgrade attack.
+        token = jwt.encode(
+            {
+                "iss": TEST_ISSUER,
+                "aud": TEST_AUDIENCE,
+                "sub": "attacker",
+                "exp": int((datetime.now(UTC) + timedelta(hours=1)).timestamp()),
+            },
+            key="",
+            algorithm="none",
+        )
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        with (
+            _patch_signing_key("unused"),
+            pytest.raises(exceptions.AuthenticationFailed),
+        ):
+            JWKSAuthentication().authenticate(request)
+
+    def test_hs256_rejected_when_expecting_rs256(self, factory):
+        """HS256 tokens (symmetric) must not verify — confused-deputy attack."""
+        token = jwt.encode(
+            {
+                "iss": TEST_ISSUER,
+                "aud": TEST_AUDIENCE,
+                "sub": "attacker",
+                "exp": int((datetime.now(UTC) + timedelta(hours=1)).timestamp()),
+            },
+            key="shared-secret",
+            algorithm="HS256",
+            headers={"kid": TEST_KID},
+        )
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        # Return an RSA public key from JWKS — PyJWT must refuse HS256 against it.
+        with (
+            _patch_signing_key(
+                rsa.generate_private_key(
+                    public_exponent=65537, key_size=2048
+                ).public_key()
+            ),
+            pytest.raises(exceptions.AuthenticationFailed),
+        ):
+            JWKSAuthentication().authenticate(request)
+
+
+# ---------------------------------------------------------------------------
+# Misconfiguration
+# ---------------------------------------------------------------------------
+
+
+class TestMisconfiguration:
+    def test_missing_jwks_url_raises(self, factory, rsa_keypair):
+        with override_settings(
+            JWKS_URL=None,
+            JWT_AUDIENCE=TEST_AUDIENCE,
+            JWT_ISSUER=TEST_ISSUER,
+        ):
+            token = _encode(rsa_keypair)
+            request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+            with pytest.raises(exceptions.AuthenticationFailed, match="JWKS_URL"):
+                JWKSAuthentication().authenticate(request)
+
+    def test_missing_audience_raises(self, factory, rsa_keypair):
+        with override_settings(
+            JWKS_URL="http://example.test/jwks",
+            JWT_AUDIENCE=None,
+            JWT_ISSUER=TEST_ISSUER,
+        ):
+            token = _encode(rsa_keypair)
+            request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+            with pytest.raises(
+                exceptions.AuthenticationFailed,
+                match="JWT_AUDIENCE and JWT_ISSUER",
+            ):
+                JWKSAuthentication().authenticate(request)
+
+    def test_missing_issuer_raises(self, factory, rsa_keypair):
+        with override_settings(
+            JWKS_URL="http://example.test/jwks",
+            JWT_AUDIENCE=TEST_AUDIENCE,
+            JWT_ISSUER=None,
+        ):
+            token = _encode(rsa_keypair)
+            request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+            with pytest.raises(
+                exceptions.AuthenticationFailed,
+                match="JWT_AUDIENCE and JWT_ISSUER",
+            ):
+                JWKSAuthentication().authenticate(request)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end harness: real HTTP JWKS + real PyJWKClient fetch
+# ---------------------------------------------------------------------------
+
+
+class TestLocalJWKSHarness:
+    """Exercise the full stack via ``scripts/local_jwks_server.py``.
+
+    This proves that a freshly-minted token signed by the dev harness can be
+    verified by :class:`JWKSAuthentication` against the harness' JWKS endpoint
+    over real HTTP — no mocks. If this test passes, the auth class is ready
+    to talk to any real IdP (Clerk, Auth0, etc.) in staging.
+    """
+
+    def test_end_to_end_token_validation(self, factory):
+        import socket
+
+        from scripts.local_jwks_server import _issue_token, serve
+
+        # Pick an ephemeral free port to avoid conflicts with concurrent CI runs.
+        with socket.socket() as s:
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
+
+        server, private_key = serve("127.0.0.1", port, kid=TEST_KID)
+        try:
+            token = _issue_token(
+                private_key,
+                kid=TEST_KID,
+                issuer=TEST_ISSUER,
+                audience=TEST_AUDIENCE,
+                subject="harness_user",
+                ttl_seconds=60,
+            )
+            with override_settings(
+                JWKS_URL=f"http://127.0.0.1:{port}/.well-known/jwks.json",
+                JWT_AUDIENCE=TEST_AUDIENCE,
+                JWT_ISSUER=TEST_ISSUER,
+            ):
+                _get_jwks_client.cache_clear()
+                request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+                principal, claims = JWKSAuthentication().authenticate(request)
+                assert principal.subject == "harness_user"
+                assert claims["iss"] == TEST_ISSUER
+                assert claims["aud"] == TEST_AUDIENCE
+        finally:
+            server.shutdown()
+            server.server_close()

--- a/uv.lock
+++ b/uv.lock
@@ -64,6 +64,39 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cffi/2.0.0/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
@@ -146,6 +179,59 @@ wheels = [
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/coverage/7.13.4/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932" },
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/coverage/7.13.4/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b" },
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/coverage/7.13.4/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246" },
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/cryptography/46.0.7/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3" },
 ]
 
 [[package]]
@@ -321,6 +407,7 @@ dependencies = [
     { name = "griddy" },
     { name = "pillow" },
     { name = "psycopg" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "pytest-cov" },
     { name = "requests" },
 ]
@@ -350,6 +437,7 @@ requires-dist = [
     { name = "griddy", specifier = ">=0.45.0,<1.0" },
     { name = "pillow", specifier = ">=12.1.0" },
     { name = "psycopg", specifier = ">=3.3.2" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "requests", specifier = ">=2.32.5" },
 ]
@@ -770,6 +858,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pycparser/3.0/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pycparser/3.0/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
@@ -844,6 +941,20 @@ source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-
 sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pygments/2.19.2/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887" }
 wheels = [
     { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pygments/2.19.2/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/" }
+sdist = { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pyjwt/2.12.1/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b" }
+wheels = [
+    { url = "https://thistle-grow-685711685350.d.codeartifact.us-east-1.amazonaws.com/pypi/griddy/simple/pyjwt/2.12.1/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a reusable `JWKSAuthentication` DRF class that validates bearer JWTs against a configurable JWKS endpoint. IdP-agnostic — same class works with Clerk, Auth0, or any JWKS provider by swapping env vars.
- Ships a local dev harness (`scripts/local_jwks_server.py`) that spins up a fake JWKS server and issues signed test tokens, so downstream work is unblocked before TGF-314 (Clerk provisioning).
- Returns a lightweight `JWTPrincipal` (frozen dataclass) rather than a Django `User` — avoids a DB hit per request; user sync will land in a later story.

## Security-relevant decisions

- `ALLOWED_ALGORITHMS = ["RS256"]` enforced at decode time. Both `alg: none` (unsigned) and HS256 (symmetric, against the confused-deputy attack) are explicitly covered by tests.
- `JWKS_URL`, `JWT_AUDIENCE`, `JWT_ISSUER` are required and validated at request time — missing config raises `AuthenticationFailed` rather than silently accepting tokens.
- JWKS key caching is delegated to `PyJWKClient` (process-local cache, default refresh behavior). Rationale documented in the module docstring; no custom cache layer needed yet.
- No `Authorization` header → `authenticate()` returns `None` (lets anonymous access or other auth classes apply). Malformed `Bearer` headers raise `AuthenticationFailed`.

## What's wired up

- `pyjwt[crypto]>=2.10.0` added to dependencies
- `JWKS_URL` / `JWT_AUDIENCE` / `JWT_ISSUER` pulled from env in `gam/settings.py`
- This PR does **not** yet add `JWKSAuthentication` to `DEFAULT_AUTHENTICATION_CLASSES` — that belongs to a later story once Clerk is provisioned and a real JWKS URL is available in each environment.

## Test plan

- [x] `uv run pytest tests/test_jwks_auth.py` — 24 tests pass (header parsing, valid/expired/wrong-audience/wrong-issuer/malformed tokens, alg-downgrade rejection, misconfiguration, end-to-end via real HTTP against the dev harness)
- [x] `uv run pytest` — full suite passes (573 tests)
- [x] `uv run ruff check .` clean, `uv run ruff format .` clean
- [x] `uv run python manage.py check --settings=gam.settings_ci` clean
- [ ] Exercise end-to-end manually: `python scripts/local_jwks_server.py --issue`, export the three env vars, hit a protected endpoint with the printed token (deferred — no protected endpoints exist yet; covered by the in-process `TestLocalJWKSHarness` test)

Closes #313