### PR TITLE
feat(GAM #315): wire Django/DRF settings to Clerk instance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Database
+PG_HOST=localhost
+PG_PORT=5432
+PG_DATABASE=griddy
+PG_USER=postgres
+PG_PASSWORD=postgres
+
+# Clerk (Auth)
+# JWKS endpoint Django fetches Clerk's public signing keys from.
+CLERK_JWKS_URL="https://casual-earwig-79.clerk.accounts.dev/.well-known/jwks.json"
+# Clerk Frontend API URL — must equal the `iss` claim on every token.
+CLERK_ISSUER="https://casual-earwig-79.clerk.accounts.dev"
+# API identifier Clerk stamps into the `aud` claim (Sessions → Customize session token).
+CLERK_AUDIENCE="https://api.griddy.football"
+# Comma-separated origins allowed in the `azp` claim. Leave blank to skip the
+# check (e.g. when using the local JWKS harness in scripts/local_jwks_server.py).
+CLERK_AUTHORIZED_PARTIES="http://localhost:3000"
+# Server-side Clerk Backend API key. Production reads this from AWS Secrets
+# Manager, not from .env. Used for user lookups (TGF-317), not token verification.
+CLERK_SECRET_KEY=

--- a/README.md
+++ b/README.md
@@ -62,6 +62,53 @@ The admin interface is available at `http://localhost:8000/admin/`.
 | `GRIDDY_NFL_PASSWORD` | NFL.com password for authenticated scraping |
 | `MEDIA_ROOT` | Directory for uploaded media files (team logos, etc.) |
 | `AWS_CODEARTIFACT_TOKEN` | Authentication token for AWS CodeArtifact |
+| `CLERK_JWKS_URL` | Clerk JWKS endpoint Django fetches public signing keys from |
+| `CLERK_ISSUER` | Clerk Frontend API URL — must equal the `iss` claim on every token |
+| `CLERK_AUDIENCE` | API identifier Clerk stamps into the `aud` claim |
+| `CLERK_AUTHORIZED_PARTIES` | Comma-separated origins allowed in the `azp` claim |
+| `CLERK_SECRET_KEY` | Server-side Clerk Backend API key (loaded from AWS Secrets Manager in deployed envs) |
+
+See `.env.example` for development defaults.
+
+## Authentication
+
+GAM uses [Clerk](https://clerk.com/)-issued JWTs for API authentication, verified via
+the JWKS-based `JWKSAuthentication` class registered as DRF's
+`DEFAULT_AUTHENTICATION_CLASSES`. The auth class itself is IdP-agnostic — it reads
+generic `JWKS_URL`, `JWT_AUDIENCE`, `JWT_ISSUER`, and `JWT_AUTHORIZED_PARTIES`
+settings; `gam/settings.py` is the single place that names Clerk as the provider.
+
+### Smoke-testing against the dev Clerk instance
+
+1. Ensure `.env` is populated from `.env.example`. The dev `CLERK_JWKS_URL`,
+   `CLERK_ISSUER`, and `CLERK_AUDIENCE` already point at the shared
+   `casual-earwig-79` dev instance.
+2. Mint a token from a real Clerk session. Two options:
+   - **Account Portal** — open `https://casual-earwig-79.accounts.dev`, sign in
+     as a test user (provisioned in TGF-314), and copy the `__session` cookie
+     value from the browser DevTools.
+   - **Dashboard impersonation** — Clerk Dashboard → Users → pick a user →
+     "Impersonate user" → grab the session token.
+3. Paste the token into [jwt.io](https://jwt.io) and confirm `aud` matches your
+   `CLERK_AUDIENCE` and `iss` matches `CLERK_ISSUER`.
+4. Hit the API:
+
+   ```bash
+   uv run manage.py runserver
+   curl -H "Authorization: Bearer <token>" \
+        http://127.0.0.1:8000/api/v1/leagues/
+   ```
+
+   A 200 confirms end-to-end token validation. A 401 with
+   `{"detail": "Invalid authorized party."}` means your token's `azp` is not in
+   `CLERK_AUTHORIZED_PARTIES` (likely the portal origin differs from
+   `http://localhost:3000`).
+
+### Local JWKS harness (no Clerk required)
+
+For tests and offline dev, `scripts/local_jwks_server.py` boots a local JWKS
+server and emits a signed token. Leave `CLERK_AUTHORIZED_PARTIES` blank to
+skip the `azp` check when using the harness.
 
 ## Architecture
 

--- a/docs/api-authentication.md
+++ b/docs/api-authentication.md
@@ -1,0 +1,124 @@
+# API Authentication
+
+GAM's REST API uses bearer JWTs validated against a JWKS endpoint
+(`gam.auth.jwt.JWKSAuthentication`). In production this is wired to a
+[Clerk](https://clerk.com) instance, but the auth class is IdP-agnostic — any
+JWKS-based issuer works.
+
+This page covers how to obtain a token for hitting the API from scripts,
+`curl`, `httpie`, integration tests, or CI.
+
+## Settings
+
+The DRF auth class reads these Django settings (sourced from environment
+variables in `gam/settings.py`):
+
+| Setting | Env var | Purpose |
+|---|---|---|
+| `JWKS_URL` | `CLERK_JWKS_URL` | JWKS endpoint to fetch signing keys from |
+| `JWT_ISSUER` | `CLERK_ISSUER` | Required `iss` claim |
+| `JWT_AUDIENCE` | `CLERK_AUDIENCE` | Required `aud` claim |
+| `JWT_AUTHORIZED_PARTIES` | `CLERK_AUTHORIZED_PARTIES` | Comma-separated allowed `azp` values; skipped if empty |
+| `CLERK_SECRET_KEY` | `CLERK_SECRET_KEY` | Backend API key (token minting only) |
+
+A request authenticates by sending `Authorization: Bearer <jwt>`. If the
+header is missing the request falls through to anonymous; if it is present
+but invalid the request is rejected with `401`.
+
+## Option 1 — Mint a Clerk token via Backend API
+
+For local dev or CI against a Clerk *development* instance, use the helper
+script at `scripts/mint_clerk_token.py`. It creates a session for an existing
+Clerk user and exchanges it for a JWT in two Backend API calls.
+
+### Prerequisites
+
+- `CLERK_SECRET_KEY` set to your Clerk dev instance secret key.
+- A Clerk user ID (e.g. `user_2abcDEF...`) — find one in the Clerk dashboard.
+- The same Clerk instance configured on the Django side (`CLERK_JWKS_URL`,
+  `CLERK_ISSUER`, `CLERK_AUDIENCE`).
+
+### Usage
+
+```bash
+export CLERK_SECRET_KEY=sk_test_...
+
+# Default session token:
+python scripts/mint_clerk_token.py --user-id user_2abcDEF...
+
+# Token shaped by a specific Clerk JWT template (matches GAM's audience):
+python scripts/mint_clerk_token.py --user-id user_2abcDEF... --template griddy-api
+
+# Inline into a curl call:
+TOKEN=$(python scripts/mint_clerk_token.py --user-id user_2abcDEF...)
+curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/api/v1/leagues/
+```
+
+The token is printed to stdout on success; errors go to stderr with a
+non-zero exit code.
+
+### Unset `CLERK_AUTHORIZED_PARTIES` for this flow
+
+Backend-API-minted tokens do **not** carry an `azp` claim — Clerk only sets
+`azp` on tokens issued through the Frontend API, where the requesting origin
+is known. If `CLERK_AUTHORIZED_PARTIES` is set in your local env, the
+`_enforce_authorized_party` check will reject these tokens with
+`Invalid authorized party.`
+
+Leave the var unset (or empty) in local `.env` files; the auth class skips
+the check when the setting is empty. Keep it populated in production, where
+all real traffic comes through the frontend.
+
+### When this does *not* work
+
+Clerk **production** instances reject `POST /v1/sessions` with a
+`actor_token_creation_unauthorized`-style error. For production-like testing,
+either point the script at a dev instance or sign in through the frontend and
+copy the token from `useAuth().getToken()` in the browser.
+
+## Option 2 — Local JWKS server (no Clerk required)
+
+When you want to exercise auth without any IdP at all, use
+`scripts/local_jwks_server.py`. It generates a fresh RSA keypair, serves a
+JWKS document, and prints a signed JWT — the Django app just needs to point
+its `JWKS_URL`/`JWT_ISSUER`/`JWT_AUDIENCE` at the local server's defaults.
+
+```bash
+# Terminal 1 — serve JWKS and emit a token:
+python scripts/local_jwks_server.py --issue
+
+# Terminal 2 — point Django at it:
+export JWKS_URL=http://127.0.0.1:8765/.well-known/jwks.json
+export JWT_ISSUER=https://local.griddy.test
+export JWT_AUDIENCE=griddy-api-local
+curl -H "Authorization: Bearer <token-from-terminal-1>" \
+     http://127.0.0.1:8000/api/v1/leagues/
+```
+
+Tokens do not survive a server restart — the keypair is regenerated each
+time. This is intentional: the script is a dev aid, not a persistent IdP.
+
+## Option 3 — Frontend session token
+
+For browser-driven testing or when integrating a real frontend, call
+`getToken()` from Clerk's React/Next SDK:
+
+```typescript
+import { useAuth } from "@clerk/clerk-react";
+
+const { getToken } = useAuth();
+const token = await getToken();              // default session token
+const apiToken = await getToken({ template: "griddy-api" }); // custom template
+```
+
+Pass the result through as `Authorization: Bearer <token>` on `fetch` calls.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `Invalid issuer.` | `CLERK_ISSUER` does not match the token's `iss`. |
+| `Invalid audience.` | Token was minted without (or with the wrong) JWT template; set `--template` to one whose audience matches `CLERK_AUDIENCE`. |
+| `Invalid authorized party.` | `CLERK_AUTHORIZED_PARTIES` is set but the token's `azp` is missing or not in the list. Backend-API-minted tokens (from `mint_clerk_token.py`) and `local_jwks_server.py` tokens have no `azp` — leave the env var empty for those flows. |
+| `Token has expired.` | Mint a fresh one — Clerk session tokens default to ~60s TTL. |
+| `Unable to resolve signing key` | `CLERK_JWKS_URL` is wrong or unreachable from the Django process. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,3 +38,7 @@ See the [Getting Started](getting-started.md) guide for installation and setup i
 ## Architecture
 
 See the [Architecture](architecture.md) page for a detailed description of the data model and scraper hierarchy.
+
+## API Authentication
+
+See [API Authentication](api-authentication.md) for how to obtain a bearer token for the REST API, including a helper script for minting Clerk tokens programmatically.

--- a/gam/auth/jwt.py
+++ b/gam/auth/jwt.py
@@ -120,7 +120,7 @@ class JWKSAuthentication(authentication.BaseAuthentication):
 
         try:
             signing_key = _get_jwks_client().get_signing_key_from_jwt(token).key
-            return jwt.decode(
+            claims = jwt.decode(
                 token,
                 signing_key,
                 algorithms=ALLOWED_ALGORITHMS,
@@ -145,3 +145,23 @@ class JWKSAuthentication(authentication.BaseAuthentication):
             ) from exc
         except jwt.PyJWTError as exc:
             raise exceptions.AuthenticationFailed(f"Invalid token: {exc}") from exc
+
+        self._enforce_authorized_party(claims)
+        return claims
+
+    @staticmethod
+    def _enforce_authorized_party(claims: dict[str, Any]) -> None:
+        """Reject tokens whose ``azp`` claim is not in ``JWT_AUTHORIZED_PARTIES``.
+
+        If the setting is empty or unset, the check is skipped — useful for
+        local dev harnesses that issue tokens without an ``azp`` claim. When
+        configured, the claim must be present and exactly match one of the
+        allowed origins; this is what binds a Clerk-issued token to the
+        portal frontend that requested it.
+        """
+        allowed = getattr(settings, "JWT_AUTHORIZED_PARTIES", None) or []
+        if not allowed:
+            return
+        azp = claims.get("azp")
+        if azp not in allowed:
+            raise exceptions.AuthenticationFailed("Invalid authorized party.")

--- a/gam/settings.py
+++ b/gam/settings.py
@@ -132,10 +132,22 @@ MEDIA_ROOT = os.getenv("MEDIA_ROOT")
 GRIDDY_NFL_EMAIL = os.getenv("GRIDDY_NFL_EMAIL")
 GRIDDY_NFL_PASSWORD = os.getenv("GRIDDY_NFL_PASSWORD")
 
-# JWT / JWKS authentication — IdP-agnostic (works with Clerk, Auth0, etc.)
-JWKS_URL = os.getenv("JWKS_URL")
-JWT_AUDIENCE = os.getenv("JWT_AUDIENCE")
-JWT_ISSUER = os.getenv("JWT_ISSUER")
+# JWT / JWKS authentication — IdP-agnostic class fed from Clerk-named env vars.
+# The auth class itself is IdP-agnostic; settings.py is the one place we name the
+# IdP. Swap providers by changing these env vars (and the dashboard/secret-store
+# that owns them) without touching the auth class.
+JWKS_URL = os.getenv("CLERK_JWKS_URL")
+JWT_AUDIENCE = os.getenv("CLERK_AUDIENCE")
+JWT_ISSUER = os.getenv("CLERK_ISSUER")
+JWT_AUTHORIZED_PARTIES = [
+    party.strip()
+    for party in os.getenv("CLERK_AUTHORIZED_PARTIES", "").split(",")
+    if party.strip()
+]
+# Server-side Clerk Backend API key. Loaded from AWS Secrets Manager in
+# deployed envs; .env in dev. Reserved for user-lookup work in TGF-317; not
+# used for token verification.
+CLERK_SECRET_KEY = os.getenv("CLERK_SECRET_KEY")
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/6.0/ref/settings/#default-auto-field
@@ -201,9 +213,9 @@ REST_FRAMEWORK = {
         "rest_framework.filters.SearchFilter",
         "rest_framework.filters.OrderingFilter",
     ],
-    # "DEFAULT_AUTHENTICATION_CLASSES": [
-    #     # TODO: Decide on this
-    # ]
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "gam.auth.jwt.JWKSAuthentication",
+    ],
     # "DEFAULT_PERMISSION_CLASSES": [
     #     # TODO: Decide on this
     # ]

--- a/scripts/mint_clerk_token.py
+++ b/scripts/mint_clerk_token.py
@@ -1,0 +1,127 @@
+"""
+Mint a Clerk session JWT for a given user via Clerk's Backend API.
+
+Useful for hitting GAM's authenticated DRF endpoints from scripts, ``curl``,
+``httpie``, or test harnesses without driving a browser sign-in flow.
+
+The script does two Backend API calls:
+
+1. ``POST /v1/sessions`` to create (or reuse) a session for the user.
+2. ``POST /v1/sessions/<session_id>/tokens[/<template>]`` to mint a JWT.
+
+Both calls require ``CLERK_SECRET_KEY``. Direct session creation is permitted
+on Clerk *development* instances; production instances reject it, so this
+script is intended for local dev and CI against a dev instance only.
+
+Usage::
+
+    export CLERK_SECRET_KEY=sk_test_...
+    python scripts/mint_clerk_token.py --user-id user_2abcDEF...
+
+    # With a custom JWT template (matches GAM's configured audience):
+    python scripts/mint_clerk_token.py --user-id user_... --template griddy-api
+
+    # Drop straight into a curl call:
+    TOKEN=$(python scripts/mint_clerk_token.py --user-id user_...)
+    curl -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8000/api/v1/leagues/
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import requests
+
+CLERK_API_BASE = "https://api.clerk.com/v1"
+
+
+def _auth_headers(secret_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {secret_key}",
+        "Content-Type": "application/json",
+    }
+
+
+def create_session(secret_key: str, user_id: str, *, timeout: float) -> str:
+    response = requests.post(
+        f"{CLERK_API_BASE}/sessions",
+        headers=_auth_headers(secret_key),
+        json={"user_id": user_id},
+        timeout=timeout,
+    )
+    if not response.ok:
+        raise RuntimeError(
+            f"Clerk session creation failed ({response.status_code}): {response.text}"
+        )
+    session_id = response.json().get("id")
+    if not session_id:
+        raise RuntimeError(f"Clerk session response missing 'id': {response.text}")
+    return session_id
+
+
+def mint_token(
+    secret_key: str,
+    session_id: str,
+    *,
+    template: str | None,
+    timeout: float,
+) -> str:
+    path = f"/sessions/{session_id}/tokens"
+    if template:
+        path = f"{path}/{template}"
+    response = requests.post(
+        f"{CLERK_API_BASE}{path}",
+        headers=_auth_headers(secret_key),
+        timeout=timeout,
+    )
+    if not response.ok:
+        raise RuntimeError(
+            f"Clerk token mint failed ({response.status_code}): {response.text}"
+        )
+    jwt_value = response.json().get("jwt")
+    if not jwt_value:
+        raise RuntimeError(f"Clerk token response missing 'jwt': {response.text}")
+    return jwt_value
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--user-id",
+        required=True,
+        help="Clerk user ID (e.g. user_2abcDEF...). Find via the Clerk dashboard.",
+    )
+    parser.add_argument(
+        "--template",
+        default=None,
+        help=(
+            "Optional Clerk JWT template name. Use this when the API expects a "
+            "specific audience or custom claims; omit for the default session token."
+        ),
+    )
+    parser.add_argument(
+        "--secret-key",
+        default=os.getenv("CLERK_SECRET_KEY"),
+        help="Clerk secret key. Defaults to $CLERK_SECRET_KEY.",
+    )
+    parser.add_argument("--timeout", type=float, default=10.0)
+    args = parser.parse_args(argv)
+
+    if not args.secret_key:
+        parser.error("CLERK_SECRET_KEY is not set and --secret-key was not provided.")
+
+    session_id = create_session(args.secret_key, args.user_id, timeout=args.timeout)
+    token = mint_token(
+        args.secret_key,
+        session_id,
+        template=args.template,
+        timeout=args.timeout,
+    )
+    sys.stdout.write(token + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_clerk_settings.py
+++ b/tests/test_clerk_settings.py
@@ -1,0 +1,109 @@
+"""
+Tests for the Clerk settings wiring (TGF-315).
+
+These cover the bridge from Clerk-named env vars to the IdP-agnostic Django
+settings consumed by :class:`gam.auth.jwt.JWKSAuthentication`, plus the DRF
+``DEFAULT_AUTHENTICATION_CLASSES`` registration. The auth-class behavior
+itself is covered by ``test_jwks_auth.py``.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+from django.conf import settings
+
+
+def test_jwks_auth_in_default_authentication_classes():
+    """JWKSAuthentication must be wired as a default DRF auth class."""
+    auth_classes = settings.REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"]
+    assert "gam.auth.jwt.JWKSAuthentication" in auth_classes
+
+
+def test_clerk_settings_attributes_exist():
+    """Settings module must expose every Clerk-bridged value."""
+    for attr in (
+        "JWKS_URL",
+        "JWT_AUDIENCE",
+        "JWT_ISSUER",
+        "JWT_AUTHORIZED_PARTIES",
+        "CLERK_SECRET_KEY",
+    ):
+        assert hasattr(settings, attr), f"settings.{attr} is missing"
+
+
+def test_authorized_parties_defaults_to_empty_list_when_unset(monkeypatch):
+    """Unset env var → empty list (no enforcement)."""
+    monkeypatch.delenv("CLERK_AUTHORIZED_PARTIES", raising=False)
+    import gam.settings as gam_settings
+
+    importlib.reload(gam_settings)
+    assert gam_settings.JWT_AUTHORIZED_PARTIES == []
+
+
+def test_authorized_parties_parses_comma_separated_values(monkeypatch):
+    monkeypatch.setenv(
+        "CLERK_AUTHORIZED_PARTIES",
+        "http://localhost:3000,https://portal.griddy.test",
+    )
+    import gam.settings as gam_settings
+
+    importlib.reload(gam_settings)
+    assert gam_settings.JWT_AUTHORIZED_PARTIES == [
+        "http://localhost:3000",
+        "https://portal.griddy.test",
+    ]
+
+
+def test_authorized_parties_strips_whitespace_and_skips_empties(monkeypatch):
+    monkeypatch.setenv(
+        "CLERK_AUTHORIZED_PARTIES",
+        " http://localhost:3000 , ,https://portal.griddy.test ",
+    )
+    import gam.settings as gam_settings
+
+    importlib.reload(gam_settings)
+    assert gam_settings.JWT_AUTHORIZED_PARTIES == [
+        "http://localhost:3000",
+        "https://portal.griddy.test",
+    ]
+
+
+def test_clerk_env_vars_drive_jwks_settings(monkeypatch):
+    """Each generic JWT setting reads from its CLERK_* env var counterpart."""
+    monkeypatch.setenv(
+        "CLERK_JWKS_URL", "https://example.clerk.accounts.dev/.well-known/jwks.json"
+    )
+    monkeypatch.setenv("CLERK_ISSUER", "https://example.clerk.accounts.dev")
+    monkeypatch.setenv("CLERK_AUDIENCE", "https://api.griddy.test")
+    monkeypatch.setenv("CLERK_SECRET_KEY", "sk_test_dummy")
+    import gam.settings as gam_settings
+
+    importlib.reload(gam_settings)
+    assert (
+        gam_settings.JWKS_URL
+        == "https://example.clerk.accounts.dev/.well-known/jwks.json"
+    )
+    assert gam_settings.JWT_ISSUER == "https://example.clerk.accounts.dev"
+    assert gam_settings.JWT_AUDIENCE == "https://api.griddy.test"
+    assert gam_settings.CLERK_SECRET_KEY == "sk_test_dummy"
+
+
+def test_settings_reload_with_no_clerk_env_yields_none(monkeypatch):
+    """Reloading with no Clerk env vars yields ``None`` values, not stale ones."""
+    for var in (
+        "CLERK_JWKS_URL",
+        "CLERK_ISSUER",
+        "CLERK_AUDIENCE",
+        "CLERK_AUTHORIZED_PARTIES",
+        "CLERK_SECRET_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    import gam.settings as gam_settings
+
+    importlib.reload(gam_settings)
+    assert gam_settings.JWKS_URL is None
+    assert gam_settings.JWT_ISSUER is None
+    assert gam_settings.JWT_AUDIENCE is None
+    assert gam_settings.CLERK_SECRET_KEY is None
+    assert gam_settings.JWT_AUTHORIZED_PARTIES == []

--- a/tests/test_jwks_auth.py
+++ b/tests/test_jwks_auth.py
@@ -373,6 +373,104 @@ class TestMisconfiguration:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Authorized-party enforcement (TGF-315)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorizedParty:
+    """`azp` claim must match ``JWT_AUTHORIZED_PARTIES`` when configured."""
+
+    def test_missing_setting_skips_check(self, factory, rsa_keypair):
+        """Backwards compat: tokens issued by harnesses without ``azp`` still pass."""
+        token = _encode(rsa_keypair)
+        public_key = rsa_keypair.public_key()
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+        with override_settings(
+            JWKS_URL="http://example.test/jwks",
+            JWT_AUDIENCE=TEST_AUDIENCE,
+            JWT_ISSUER=TEST_ISSUER,
+            JWT_AUTHORIZED_PARTIES=[],
+        ):
+            with _patch_signing_key(public_key):
+                principal, _ = JWKSAuthentication().authenticate(request)
+            assert principal.subject == "user_123"
+
+    def test_matching_azp_accepted(self, factory, rsa_keypair):
+        token = _encode(
+            rsa_keypair,
+            extra_claims={"azp": "http://localhost:3000"},
+        )
+        public_key = rsa_keypair.public_key()
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+        with override_settings(
+            JWKS_URL="http://example.test/jwks",
+            JWT_AUDIENCE=TEST_AUDIENCE,
+            JWT_ISSUER=TEST_ISSUER,
+            JWT_AUTHORIZED_PARTIES=["http://localhost:3000"],
+        ):
+            with _patch_signing_key(public_key):
+                principal, claims = JWKSAuthentication().authenticate(request)
+            assert principal.subject == "user_123"
+            assert claims["azp"] == "http://localhost:3000"
+
+    def test_mismatched_azp_rejected(self, factory, rsa_keypair):
+        token = _encode(
+            rsa_keypair,
+            extra_claims={"azp": "http://evil.example"},
+        )
+        public_key = rsa_keypair.public_key()
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+        with (
+            override_settings(
+                JWKS_URL="http://example.test/jwks",
+                JWT_AUDIENCE=TEST_AUDIENCE,
+                JWT_ISSUER=TEST_ISSUER,
+                JWT_AUTHORIZED_PARTIES=["http://localhost:3000"],
+            ),
+            _patch_signing_key(public_key),
+            pytest.raises(exceptions.AuthenticationFailed, match="authorized party"),
+        ):
+            JWKSAuthentication().authenticate(request)
+
+    def test_missing_azp_rejected_when_configured(self, factory, rsa_keypair):
+        """Tokens without ``azp`` cannot satisfy a non-empty allowlist."""
+        token = _encode(rsa_keypair)
+        public_key = rsa_keypair.public_key()
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+        with (
+            override_settings(
+                JWKS_URL="http://example.test/jwks",
+                JWT_AUDIENCE=TEST_AUDIENCE,
+                JWT_ISSUER=TEST_ISSUER,
+                JWT_AUTHORIZED_PARTIES=["http://localhost:3000"],
+            ),
+            _patch_signing_key(public_key),
+            pytest.raises(exceptions.AuthenticationFailed, match="authorized party"),
+        ):
+            JWKSAuthentication().authenticate(request)
+
+    def test_multiple_allowed_parties(self, factory, rsa_keypair):
+        token = _encode(
+            rsa_keypair,
+            extra_claims={"azp": "https://portal.griddy.test"},
+        )
+        public_key = rsa_keypair.public_key()
+        request = factory.get("/", HTTP_AUTHORIZATION=f"Bearer {token}")
+        with override_settings(
+            JWKS_URL="http://example.test/jwks",
+            JWT_AUDIENCE=TEST_AUDIENCE,
+            JWT_ISSUER=TEST_ISSUER,
+            JWT_AUTHORIZED_PARTIES=[
+                "http://localhost:3000",
+                "https://portal.griddy.test",
+            ],
+        ):
+            with _patch_signing_key(public_key):
+                principal, _ = JWKSAuthentication().authenticate(request)
+            assert principal.subject == "user_123"
+
+
 class TestLocalJWKSHarness:
     """Exercise the full stack via ``scripts/local_jwks_server.py``.
 


### PR DESCRIPTION
## Summary

- Bridges Clerk-named env vars (`CLERK_JWKS_URL`, `CLERK_AUDIENCE`, `CLERK_ISSUER`, `CLERK_AUTHORIZED_PARTIES`, `CLERK_SECRET_KEY`) to the IdP-agnostic Django settings consumed by `JWKSAuthentication`.
- Registers `gam.auth.jwt.JWKSAuthentication` as DRF's `DEFAULT_AUTHENTICATION_CLASSES`.
- Enforces the `azp` claim against `JWT_AUTHORIZED_PARTIES` when the allowlist is non-empty (no-op when unset, so the local JWKS harness keeps working).
- Adds a README "Authentication" section walking devs through getting a real Clerk session token and hitting the API end-to-end.
- Annotates `.env.example` so each Clerk variable explains its role.

## Test plan

- [x] `uv run pytest` — full suite (585 tests) passes
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [ ] Manual smoke test against the dev Clerk instance using a real session token (per the new README section)

Closes #315