### PR TITLE
feat(GAM #316): define permission model and enforce in DRF

### DIFF
--- a/archive/api/viewsets/acquisition.py
+++ b/archive/api/viewsets/acquisition.py
@@ -8,9 +8,10 @@ from archive.api.serializers.acquisition import (
     AcquisitionWriteSerializer,
 )
 from archive.models import Acquisition
+from gam.auth.permissions import HoldingsPermissionMixin
 
 
-class AcquisitionViewSet(ModelViewSet):
+class AcquisitionViewSet(HoldingsPermissionMixin, ModelViewSet):
     pagination_class = DefaultCursorPagination
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["source", "rights"]

--- a/archive/api/viewsets/franchise.py
+++ b/archive/api/viewsets/franchise.py
@@ -14,9 +14,11 @@ from archive.api.serializers.franchise import (
     FranchiseWriteSerializer,
 )
 from archive.models import Franchise
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class FranchiseViewSet(
+    CatalogPermissionMixin,
     ListModelMixin,
     CreateModelMixin,
     RetrieveModelMixin,

--- a/archive/api/viewsets/game.py
+++ b/archive/api/viewsets/game.py
@@ -35,9 +35,11 @@ from archive.models import (
     RushingBoxscore,
     TacklesBoxscore,
 )
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class GameViewSet(
+    CatalogPermissionMixin,
     ListModelMixin,
     CreateModelMixin,
     RetrieveModelMixin,

--- a/archive/api/viewsets/game_completeness.py
+++ b/archive/api/viewsets/game_completeness.py
@@ -14,9 +14,11 @@ from archive.api.serializers.game_completeness import (
     GameCompletenessWriteSerializer,
 )
 from archive.models import GameCompleteness
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class GameCompletenessViewSet(
+    CatalogPermissionMixin,
     ListModelMixin,
     CreateModelMixin,
     RetrieveModelMixin,

--- a/archive/api/viewsets/game_nested.py
+++ b/archive/api/viewsets/game_nested.py
@@ -11,9 +11,10 @@ from archive.api.serializers.game_nested import (
     QuarterScoreWriteSerializer,
 )
 from archive.models import Drive, Game, GameReplay, QuarterScore
+from gam.auth.permissions import CatalogPermissionMixin
 
 
-class GameNestedMixin:
+class GameNestedMixin(CatalogPermissionMixin):
     """Mixin that scopes querysets to the parent game from the URL."""
 
     pagination_class = None  # Nested endpoints return all results for a single game

--- a/archive/api/viewsets/league.py
+++ b/archive/api/viewsets/league.py
@@ -14,9 +14,11 @@ from archive.api.serializers.league import (
     LeagueWriteSerializer,
 )
 from archive.models import League
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class LeagueViewSet(
+    CatalogPermissionMixin,
     ListModelMixin,
     CreateModelMixin,
     RetrieveModelMixin,

--- a/archive/api/viewsets/org_unit.py
+++ b/archive/api/viewsets/org_unit.py
@@ -14,9 +14,11 @@ from archive.api.serializers.org_unit import (
     OrgUnitWriteSerializer,
 )
 from archive.models import OrgUnit
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class OrgUnitViewSet(
+    CatalogPermissionMixin,
     ListModelMixin,
     CreateModelMixin,
     RetrieveModelMixin,

--- a/archive/api/viewsets/play.py
+++ b/archive/api/viewsets/play.py
@@ -15,10 +15,15 @@ from archive.api.serializers.play import (
     PlayWriteSerializer,
 )
 from archive.models import Game, Play
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class GamePlayViewSet(
-    ListModelMixin, CreateModelMixin, RetrieveModelMixin, GenericViewSet
+    CatalogPermissionMixin,
+    ListModelMixin,
+    CreateModelMixin,
+    RetrieveModelMixin,
+    GenericViewSet,
 ):
     queryset = Play.objects.none()
     pagination_class = PlayPagination

--- a/archive/api/viewsets/play_stat.py
+++ b/archive/api/viewsets/play_stat.py
@@ -7,9 +7,12 @@ from archive.api.serializers.play_stat import (
     PlayStatWriteSerializer,
 )
 from archive.models import Play, PlayStat
+from gam.auth.permissions import CatalogPermissionMixin
 
 
-class PlayStatViewSet(ListModelMixin, CreateModelMixin, GenericViewSet):
+class PlayStatViewSet(
+    CatalogPermissionMixin, ListModelMixin, CreateModelMixin, GenericViewSet
+):
     queryset = PlayStat.objects.none()
     pagination_class = None
 

--- a/archive/api/viewsets/season.py
+++ b/archive/api/viewsets/season.py
@@ -14,9 +14,11 @@ from archive.api.serializers.season import (
     SeasonWriteSerializer,
 )
 from archive.models import Season
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class SeasonViewSet(
+    CatalogPermissionMixin,
     ListModelMixin,
     CreateModelMixin,
     RetrieveModelMixin,

--- a/archive/api/viewsets/source.py
+++ b/archive/api/viewsets/source.py
@@ -7,9 +7,10 @@ from archive.api.serializers.source import (
     SourceWriteSerializer,
 )
 from archive.models import Source
+from gam.auth.permissions import HoldingsPermissionMixin
 
 
-class SourceViewSet(ModelViewSet):
+class SourceViewSet(HoldingsPermissionMixin, ModelViewSet):
     queryset = Source.objects.all()
     pagination_class = DefaultCursorPagination
 

--- a/archive/api/viewsets/standings.py
+++ b/archive/api/viewsets/standings.py
@@ -11,6 +11,7 @@ from archive.api.serializers.standings import (
     TeamStandingsSnapshotWriteSerializer,
 )
 from archive.models import TeamStandingsSnapshot
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class StandingsFilter(django_filters.FilterSet):
@@ -22,7 +23,11 @@ class StandingsFilter(django_filters.FilterSet):
 
 
 class TeamStandingsSnapshotViewSet(
-    ListModelMixin, CreateModelMixin, RetrieveModelMixin, GenericViewSet
+    CatalogPermissionMixin,
+    ListModelMixin,
+    CreateModelMixin,
+    RetrieveModelMixin,
+    GenericViewSet,
 ):
     pagination_class = DefaultCursorPagination
     filter_backends = [DjangoFilterBackend, OrderingFilter]

--- a/archive/api/viewsets/tag.py
+++ b/archive/api/viewsets/tag.py
@@ -8,16 +8,21 @@ from archive.api.serializers.tag import (
     TagSerializer,
 )
 from archive.models import AssetTag, Tag
+from gam.auth.permissions import HoldingsPermissionMixin
 
 
-class TagViewSet(ModelViewSet):
+class TagViewSet(HoldingsPermissionMixin, ModelViewSet):
     queryset = Tag.objects.all()
     serializer_class = TagSerializer
     pagination_class = DefaultCursorPagination
 
 
 class AssetTagViewSet(
-    ListModelMixin, CreateModelMixin, DestroyModelMixin, GenericViewSet
+    HoldingsPermissionMixin,
+    ListModelMixin,
+    CreateModelMixin,
+    DestroyModelMixin,
+    GenericViewSet,
 ):
     pagination_class = DefaultCursorPagination
 

--- a/archive/api/viewsets/team.py
+++ b/archive/api/viewsets/team.py
@@ -20,9 +20,11 @@ from archive.api.serializers.team import (
 )
 from archive.api.serializers.venue import VenueDetailSerializer
 from archive.models import Game, Team, TeamVenueOccupancy
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class TeamViewSet(
+    CatalogPermissionMixin,
     ListModelMixin,
     CreateModelMixin,
     RetrieveModelMixin,

--- a/archive/api/viewsets/team_affiliation.py
+++ b/archive/api/viewsets/team_affiliation.py
@@ -14,9 +14,11 @@ from archive.api.serializers.team_affiliation import (
     TeamAffiliationWriteSerializer,
 )
 from archive.models import TeamAffiliation
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class TeamAffiliationViewSet(
+    CatalogPermissionMixin,
     ListModelMixin,
     CreateModelMixin,
     RetrieveModelMixin,

--- a/archive/api/viewsets/team_venue_occupancy.py
+++ b/archive/api/viewsets/team_venue_occupancy.py
@@ -14,9 +14,11 @@ from archive.api.serializers.team_venue_occupancy import (
     TeamVenueOccupancyWriteSerializer,
 )
 from archive.models import TeamVenueOccupancy
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class TeamVenueOccupancyViewSet(
+    CatalogPermissionMixin,
     ListModelMixin,
     CreateModelMixin,
     RetrieveModelMixin,

--- a/archive/api/viewsets/venue.py
+++ b/archive/api/viewsets/venue.py
@@ -15,9 +15,11 @@ from archive.api.serializers.venue import (
     VenueWriteSerializer,
 )
 from archive.models import Venue
+from gam.auth.permissions import CatalogPermissionMixin
 
 
 class VenueViewSet(
+    CatalogPermissionMixin,
     ListModelMixin,
     CreateModelMixin,
     RetrieveModelMixin,

--- a/archive/api/viewsets/video_asset.py
+++ b/archive/api/viewsets/video_asset.py
@@ -11,6 +11,7 @@ from archive.api.serializers.video_asset import (
     VideoAssetWriteSerializer,
 )
 from archive.models import VideoAsset
+from gam.auth.permissions import HoldingsPermissionMixin
 
 
 class VideoAssetPagination(CursorPagination):
@@ -18,7 +19,7 @@ class VideoAssetPagination(CursorPagination):
     ordering = "-created_at"
 
 
-class VideoAssetViewSet(ModelViewSet):
+class VideoAssetViewSet(HoldingsPermissionMixin, ModelViewSet):
     pagination_class = VideoAssetPagination
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ["game", "asset_type", "quality_tier", "is_preferred"]

--- a/docs/api-authentication.md
+++ b/docs/api-authentication.md
@@ -43,11 +43,14 @@ Clerk user and exchanges it for a JWT in two Backend API calls.
 ```bash
 export CLERK_SECRET_KEY=sk_test_...
 
-# Default session token:
+# Default session token (use this for GAM — picks up custom claims you
+# configured under "Customize session token" in the Clerk dashboard):
 python scripts/mint_clerk_token.py --user-id user_2abcDEF...
 
-# Token shaped by a specific Clerk JWT template (matches GAM's audience):
-python scripts/mint_clerk_token.py --user-id user_2abcDEF... --template griddy-api
+# Token shaped by a specific Clerk JWT template — only needed when you
+# want a non-session token shape (third-party integrations like Supabase,
+# Firebase, Convex, etc.). Most GAM use cases do NOT need this.
+python scripts/mint_clerk_token.py --user-id user_2abcDEF... --template my-template
 
 # Inline into a curl call:
 TOKEN=$(python scripts/mint_clerk_token.py --user-id user_2abcDEF...)
@@ -107,8 +110,8 @@ For browser-driven testing or when integrating a real frontend, call
 import { useAuth } from "@clerk/clerk-react";
 
 const { getToken } = useAuth();
-const token = await getToken();              // default session token
-const apiToken = await getToken({ template: "griddy-api" }); // custom template
+const token = await getToken();              // default session token (use this for GAM)
+const supabaseToken = await getToken({ template: "supabase" }); // only for 3rd-party integrations
 ```
 
 Pass the result through as `Authorization: Bearer <token>` on `fetch` calls.
@@ -118,7 +121,7 @@ Pass the result through as `Authorization: Bearer <token>` on `fetch` calls.
 | Symptom | Likely cause |
 |---|---|
 | `Invalid issuer.` | `CLERK_ISSUER` does not match the token's `iss`. |
-| `Invalid audience.` | Token was minted without (or with the wrong) JWT template; set `--template` to one whose audience matches `CLERK_AUDIENCE`. |
+| `Invalid audience.` | `CLERK_AUDIENCE` does not match the token's `aud`. The default Clerk session token's audience is your Clerk Frontend API URL — set `CLERK_AUDIENCE` to that. Only pass `--template` if you've created a custom JWT template specifically to override the audience. |
 | `Invalid authorized party.` | `CLERK_AUTHORIZED_PARTIES` is set but the token's `azp` is missing or not in the list. Backend-API-minted tokens (from `mint_clerk_token.py`) and `local_jwks_server.py` tokens have no `azp` — leave the env var empty for those flows. |
 | `Token has expired.` | Mint a fresh one — Clerk session tokens default to ~60s TTL. |
 | `Unable to resolve signing key` | `CLERK_JWKS_URL` is wrong or unreachable from the Django process. |

--- a/docs/auth/permissions.md
+++ b/docs/auth/permissions.md
@@ -1,0 +1,142 @@
+# Permission Catalog
+
+This page is the canonical reference for the permissions the Griddy API
+recognizes, the convention used to name them, and how DRF enforces them.
+Once SDK clients depend on these strings they become a public contract —
+treat additions as cheap and removals as breaking.
+
+## Naming convention: `resource:verb`
+
+Every permission is named `<resource>:<verb>` (e.g. `catalog:read`).
+
+**Resource first, verb second.** Three reasons:
+
+1. **Sorts and globs naturally.** Listing a token's permissions groups them
+   by data domain, and future wildcard support (`catalog:*`) reads cleanly.
+2. **Verbs grow more often than resources.** New verbs (`export`, `archive`,
+   `restore`) tend to appear inside an existing domain, so resource-first
+   keeps related entries adjacent.
+3. **Colon over dot.** The colon separator matches OAuth scope conventions
+   used by Stripe, Slack, GitHub, and others — easier for SDK consumers to
+   recognize as a permission rather than a method path.
+
+The other two conventions we considered:
+
+- **`verb:resource` (GitHub-style, e.g. `read:catalog`).** Rejected because
+  it groups all read-only access together at the cost of splitting each
+  resource across multiple list positions.
+- **`resource.verb` (Google-style, e.g. `catalog.read`).** Rejected because
+  the dot is also our module-path separator and JSON access notation; using
+  it for permissions invites visual collisions.
+
+## Catalog
+
+The initial set is deliberately small. Two domains, two verbs each:
+
+| Permission | Grants | Enforced on |
+|---|---|---|
+| `catalog:read` | List/retrieve catalog resources (leagues, seasons, games, teams, venues, org units, affiliations, standings, plays, boxscores, drives, replays, completeness records). | `LeagueViewSet`, `SeasonViewSet`, `FranchiseViewSet`, `TeamViewSet`, `OrgUnitViewSet`, `TeamAffiliationViewSet`, `VenueViewSet`, `TeamVenueOccupancyViewSet`, `GameViewSet`, `GameCompletenessViewSet`, `TeamStandingsSnapshotViewSet`, `GamePlayViewSet`, `PlayStatViewSet`, all nested boxscore viewsets. |
+| `catalog:write` | Create/update/delete the same resources. | Same viewsets (write actions). |
+| `holdings:read` | List/retrieve holdings resources (sources, acquisitions, video assets, tags, asset tags). | `SourceViewSet`, `AcquisitionViewSet`, `VideoAssetViewSet`, `TagViewSet`, `AssetTagViewSet`. |
+| `holdings:write` | Create/update/delete holdings resources. | Same viewsets (write actions). |
+
+The catalog/holdings split mirrors the project's two-domain data model
+described in `archive/CLAUDE.md`. Holdings tend to be more sensitive
+(internal acquisition records, file paths) than catalog data, so we want to
+gate them with separate permissions even when read-only.
+
+## Enforcement
+
+DRF reads the permission set from the validated JWT's `permissions` claim
+(populated by Clerk — see "JWT template" below). Every viewset that should
+be gated uses one of two mixins from `gam.auth.permissions`:
+
+```python
+from gam.auth.permissions import CatalogPermissionMixin, HoldingsPermissionMixin
+
+class LeagueViewSet(CatalogPermissionMixin, ...):
+    ...
+
+class SourceViewSet(HoldingsPermissionMixin, ...):
+    ...
+```
+
+Each mixin sets `permission_classes = [HasAPIPermission]` and
+`required_permissions` to the appropriate action map.
+:class:`HasAPIPermission` looks up the current DRF action (`list`,
+`retrieve`, `create`, `update`, `partial_update`, `destroy`) in the map; if
+no entry matches, it falls back to the `default` key (used for custom
+`@action` methods).
+
+Override on a single viewset when needed:
+
+```python
+class TeamViewSet(CatalogPermissionMixin, ...):
+    required_permissions = {
+        **CATALOG_PERMISSIONS,
+        "merge": [Permissions.CATALOG_WRITE],  # custom @action
+    }
+```
+
+A view with no `required_permissions` is treated as "no permission
+required" — `HasAPIPermission` returns `True` and other permission classes
+(if any) decide the outcome.
+
+## Token format
+
+`HasAPIPermission` accepts the `permissions` claim in either form:
+
+```json
+{ "permissions": ["catalog:read", "holdings:read"] }
+```
+
+```json
+{ "permissions": "catalog:read holdings:read" }
+```
+
+The space-delimited string form mirrors how OAuth `scope` is serialized,
+making it convenient for IdPs that can only emit string claims.
+
+## JWT template (Clerk)
+
+The `permissions` claim is **not** populated automatically by Clerk; it
+must be added to the JWT template in the Clerk dashboard. Suggested
+template snippet (read from organization role + user public metadata):
+
+```json
+{
+  "permissions": "{{user.public_metadata.permissions}}"
+}
+```
+
+Or, if using Clerk Organizations:
+
+```json
+{
+  "permissions": "{{org_membership.permissions}}"
+}
+```
+
+Until the template is updated, all gated endpoints will return `403` for
+real Clerk tokens — the local-dev harness (`scripts/local_jwks_server.py`)
+and the `mint_clerk_token.py` script can include arbitrary claims for
+testing.
+
+## Adding a new permission
+
+1. Add a constant to :class:`gam.auth.permissions.Permissions`.
+2. Reference it from the appropriate action map (or create a new mixin).
+3. Document it in the table above with what it grants and where it is
+   enforced.
+4. If the permission is meant to be granted by default, update the Clerk
+   JWT template / user metadata so existing tokens carry it.
+
+Removing a permission is a breaking change for SDK clients — prefer
+deprecating (stop enforcing it, leave it in tokens) over deleting.
+
+## Out of scope (for now)
+
+Per-object permissions (e.g. "user X can edit asset Y but not Z") are
+intentionally **not** implemented in this iteration. We expect access
+patterns to clarify before designing object-level rules; revisit once
+SDK consumers and concrete tenancy requirements are in hand.

--- a/docs/auth/permissions.md
+++ b/docs/auth/permissions.md
@@ -97,11 +97,15 @@ required" — `HasAPIPermission` returns `True` and other permission classes
 The space-delimited string form mirrors how OAuth `scope` is serialized,
 making it convenient for IdPs that can only emit string claims.
 
-## JWT template (Clerk)
+## Session token customization (Clerk)
 
 The `permissions` claim is **not** populated automatically by Clerk; it
-must be added to the JWT template in the Clerk dashboard. Suggested
-template snippet (read from organization role + user public metadata):
+must be added under **Sessions → Customize session token** in the Clerk
+dashboard. Use the *session token*, not a JWT template — Clerk recommends
+session-token customization whenever you want session-bound data plus
+custom claims, and it has lower latency than custom JWT templates.
+
+Suggested claim (reads from user public metadata):
 
 ```json
 {
@@ -117,10 +121,16 @@ Or, if using Clerk Organizations:
 }
 ```
 
-Until the template is updated, all gated endpoints will return `403` for
-real Clerk tokens — the local-dev harness (`scripts/local_jwks_server.py`)
-and the `mint_clerk_token.py` script can include arbitrary claims for
-testing.
+Reach for a JWT template (Dashboard → JWT Templates) only when you need a
+token with a different shape than Clerk's default session token — e.g.
+for a third-party integration like Supabase or Firebase that requires a
+specific audience/issuer/claim set. Tokens minted from a JWT template
+cannot include session-bound claims like `sid`, `v`, `pla`, or `fea`.
+
+Until the session token claim is configured, all gated endpoints will
+return `403` for real Clerk tokens — the local-dev harness
+(`scripts/local_jwks_server.py`) and the `mint_clerk_token.py` script can
+include arbitrary claims for testing.
 
 ## Adding a new permission
 
@@ -129,7 +139,7 @@ testing.
 3. Document it in the table above with what it grants and where it is
    enforced.
 4. If the permission is meant to be granted by default, update the Clerk
-   JWT template / user metadata so existing tokens carry it.
+   session token claim / user metadata so existing tokens carry it.
 
 Removing a permission is a breaking change for SDK clients — prefer
 deprecating (stop enforcing it, leave it in tokens) over deleting.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,3 +42,7 @@ See the [Architecture](architecture.md) page for a detailed description of the d
 ## API Authentication
 
 See [API Authentication](api-authentication.md) for how to obtain a bearer token for the REST API, including a helper script for minting Clerk tokens programmatically.
+
+## Permissions
+
+See [Permission Catalog](auth/permissions.md) for the list of permissions the API recognizes, the `resource:verb` naming convention, and how DRF enforces them.

--- a/gam/auth/permissions.py
+++ b/gam/auth/permissions.py
@@ -1,0 +1,141 @@
+"""
+Permission catalog and DRF permission class for the Griddy API.
+
+The catalog is intentionally small (4 entries). Adding a new permission later
+is cheap; removing one is a breaking change once SDK clients depend on it.
+
+Tokens carry permissions in a ``permissions`` claim, accepted as either a
+list of strings or a single space-delimited string (mirroring OAuth scope
+conventions). The claim is populated by the IdP — for Clerk this is done in
+the JWT template (see ``docs/auth/permissions.md``).
+
+Naming convention: ``resource:verb`` (e.g. ``catalog:read``). See
+``docs/auth/permissions.md`` for the rationale.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any, ClassVar
+
+from rest_framework import permissions
+from rest_framework.request import Request
+from rest_framework.views import APIView
+
+
+class Permissions:
+    """Constants for every permission the API recognizes.
+
+    Reference these from viewsets instead of inlining string literals so the
+    catalog has a single source of truth and IDEs can find every usage.
+    """
+
+    CATALOG_READ = "catalog:read"
+    CATALOG_WRITE = "catalog:write"
+    HOLDINGS_READ = "holdings:read"
+    HOLDINGS_WRITE = "holdings:write"
+
+
+# Action → required permissions mappings shared by viewsets in each domain.
+# Keys are DRF action names (``list``, ``retrieve``, ``create``, ``update``,
+# ``partial_update``, ``destroy``); the ``default`` key catches custom
+# ``@action`` methods and any unmapped actions.
+CATALOG_PERMISSIONS: dict[str, list[str]] = {
+    "list": [Permissions.CATALOG_READ],
+    "retrieve": [Permissions.CATALOG_READ],
+    "create": [Permissions.CATALOG_WRITE],
+    "update": [Permissions.CATALOG_WRITE],
+    "partial_update": [Permissions.CATALOG_WRITE],
+    "destroy": [Permissions.CATALOG_WRITE],
+    "default": [Permissions.CATALOG_READ],
+}
+
+HOLDINGS_PERMISSIONS: dict[str, list[str]] = {
+    "list": [Permissions.HOLDINGS_READ],
+    "retrieve": [Permissions.HOLDINGS_READ],
+    "create": [Permissions.HOLDINGS_WRITE],
+    "update": [Permissions.HOLDINGS_WRITE],
+    "partial_update": [Permissions.HOLDINGS_WRITE],
+    "destroy": [Permissions.HOLDINGS_WRITE],
+    "default": [Permissions.HOLDINGS_READ],
+}
+
+
+def _coerce_permissions(value: Any) -> set[str]:
+    """Normalize a token's ``permissions`` claim into a set of strings.
+
+    Accepts a list/tuple of strings or a single space-delimited string.
+    Anything else (including ``None``) becomes an empty set.
+    """
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        return set(value.split())
+    if isinstance(value, Iterable):
+        return {str(item) for item in value}
+    return set()
+
+
+class HasAPIPermission(permissions.BasePermission):
+    """Check that the JWT carries every permission the view requires.
+
+    Views declare ``required_permissions`` as one of:
+
+    * a list/tuple/string of permission strings (applies to all actions), or
+    * a dict keyed by DRF action name (or HTTP method, lowercased), with a
+      ``"default"`` key as a fallback for unmapped actions/custom @actions.
+
+    A view with no ``required_permissions`` (or an empty value) is treated as
+    not requiring any permission and is left to other permission classes to
+    gate. This keeps the class safe to install as a project-wide default.
+    """
+
+    message = "Token is missing one or more required permissions."
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        required = self._required_for_action(request, view)
+        if not required:
+            return True
+        token_perms = self._token_permissions(request)
+        return required.issubset(token_perms)
+
+    @staticmethod
+    def _token_permissions(request: Request) -> set[str]:
+        claims = getattr(request, "auth", None) or {}
+        if not isinstance(claims, dict):
+            return set()
+        return _coerce_permissions(claims.get("permissions"))
+
+    @staticmethod
+    def _required_for_action(request: Request, view: APIView) -> set[str]:
+        spec = getattr(view, "required_permissions", None)
+        if not spec:
+            return set()
+        if isinstance(spec, dict):
+            action = getattr(view, "action", None) or request.method.lower()
+            value = spec.get(action)
+            if value is None:
+                value = spec.get("default", [])
+            return _coerce_permissions(value)
+        return _coerce_permissions(spec)
+
+
+class CatalogPermissionMixin:
+    """Apply :data:`CATALOG_PERMISSIONS` to a viewset.
+
+    Inheriting viewsets get :class:`HasAPIPermission` enforcement automatically.
+    Override ``required_permissions`` on the subclass to customize.
+    """
+
+    permission_classes: ClassVar[list[type]] = [HasAPIPermission]
+    required_permissions: ClassVar[dict[str, list[str]]] = CATALOG_PERMISSIONS
+
+
+class HoldingsPermissionMixin:
+    """Apply :data:`HOLDINGS_PERMISSIONS` to a viewset.
+
+    See :class:`CatalogPermissionMixin` for usage.
+    """
+
+    permission_classes: ClassVar[list[type]] = [HasAPIPermission]
+    required_permissions: ClassVar[dict[str, list[str]]] = HOLDINGS_PERMISSIONS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,3 +86,6 @@ python_files = ["tests.py", "test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "--no-migrations"
+markers = [
+    "enforce_api_permissions: do not bypass HasAPIPermission for this test",
+]

--- a/scripts/mint_clerk_token.py
+++ b/scripts/mint_clerk_token.py
@@ -1,5 +1,5 @@
 """
-Mint a Clerk session JWT for a given user via Clerk's Backend API.
+Mint a Clerk session token for a given user via Clerk's Backend API.
 
 Useful for hitting GAM's authenticated DRF endpoints from scripts, ``curl``,
 ``httpie``, or test harnesses without driving a browser sign-in flow.
@@ -7,19 +7,29 @@ Useful for hitting GAM's authenticated DRF endpoints from scripts, ``curl``,
 The script does two Backend API calls:
 
 1. ``POST /v1/sessions`` to create (or reuse) a session for the user.
-2. ``POST /v1/sessions/<session_id>/tokens[/<template>]`` to mint a JWT.
+2. ``POST /v1/sessions/<session_id>/tokens[/<template>]`` to mint a token.
 
 Both calls require ``CLERK_SECRET_KEY``. Direct session creation is permitted
 on Clerk *development* instances; production instances reject it, so this
 script is intended for local dev and CI against a dev instance only.
+
+Without ``--template``, you get the default Clerk **session token**, which
+picks up custom claims you configured under "Customize session token" in
+the Clerk dashboard (e.g. the ``permissions`` claim GAM reads — see
+``docs/auth/permissions.md``). This is what almost all GAM use cases want.
+
+Pass ``--template`` only when you need a token shaped by a custom **JWT
+template** — typically for a third-party integration (Supabase, Firebase,
+Convex, Hasura) that requires a specific audience/issuer/claim set. JWT
+templates cannot include session-bound claims like ``sid``.
 
 Usage::
 
     export CLERK_SECRET_KEY=sk_test_...
     python scripts/mint_clerk_token.py --user-id user_2abcDEF...
 
-    # With a custom JWT template (matches GAM's configured audience):
-    python scripts/mint_clerk_token.py --user-id user_... --template griddy-api
+    # Only when targeting a custom JWT template (e.g. for Supabase):
+    python scripts/mint_clerk_token.py --user-id user_... --template supabase
 
     # Drop straight into a curl call:
     TOKEN=$(python scripts/mint_clerk_token.py --user-id user_...)
@@ -97,8 +107,10 @@ def main(argv: list[str] | None = None) -> int:
         "--template",
         default=None,
         help=(
-            "Optional Clerk JWT template name. Use this when the API expects a "
-            "specific audience or custom claims; omit for the default session token."
+            "Optional Clerk JWT template name. Only set this when targeting a "
+            "third-party integration (Supabase, Firebase, etc.) that requires a "
+            "specific token shape. Omit to get the default session token, which "
+            "is what GAM expects."
         ),
     )
     parser.add_argument(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+"""
+Shared pytest fixtures for the GAM test suite.
+
+Most existing API tests predate :class:`gam.auth.permissions.HasAPIPermission`
+and hit endpoints anonymously. To keep them green without adding token
+plumbing to every test, the autouse fixture below short-circuits permission
+checks. Tests that explicitly verify enforcement (TGF-316) opt back into the
+real check via the ``enforce_api_permissions`` marker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _bypass_api_permissions(request, monkeypatch):
+    if "enforce_api_permissions" in request.keywords:
+        return
+    from gam.auth.permissions import HasAPIPermission
+
+    monkeypatch.setattr(
+        HasAPIPermission, "has_permission", lambda self, req, view: True
+    )

--- a/tests/test_api_permissions.py
+++ b/tests/test_api_permissions.py
@@ -1,0 +1,361 @@
+"""
+Unit and integration tests for :class:`gam.auth.permissions.HasAPIPermission`
+and the catalog/holdings permission mixins (TGF-316).
+
+The unit block exercises claim parsing, action dispatch, and the various
+``required_permissions`` shapes the class supports. The integration block
+proves enforcement actually fires through DRF on a real viewset for each of
+the four catalog entries.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from archive.api.viewsets.league import LeagueViewSet
+from archive.api.viewsets.source import SourceViewSet
+from archive.models import League, Source
+from gam.auth.jwt import JWTPrincipal
+from gam.auth.permissions import (
+    CATALOG_PERMISSIONS,
+    HOLDINGS_PERMISSIONS,
+    CatalogPermissionMixin,
+    HasAPIPermission,
+    HoldingsPermissionMixin,
+    Permissions,
+)
+
+# Every test in this module verifies the real enforcement path; opt out of
+# the project-wide conftest bypass.
+pytestmark = pytest.mark.enforce_api_permissions
+
+
+# ---------------------------------------------------------------------------
+# Token-claim parsing
+# ---------------------------------------------------------------------------
+
+
+class _StubView:
+    def __init__(self, action="list", required_permissions=None):
+        self.action = action
+        self.required_permissions = required_permissions
+
+
+def _request(factory, *, claims, method="get"):
+    builder = getattr(factory, method)
+    request = builder("/")
+    request.auth = claims
+    return request
+
+
+@pytest.fixture
+def factory() -> APIRequestFactory:
+    return APIRequestFactory()
+
+
+class TestTokenPermissionParsing:
+    @pytest.mark.parametrize(
+        "claim_value,expected",
+        [
+            (["catalog:read", "holdings:read"], {"catalog:read", "holdings:read"}),
+            ("catalog:read holdings:read", {"catalog:read", "holdings:read"}),
+            ("catalog:read", {"catalog:read"}),
+            ("", set()),
+            ([], set()),
+            (None, set()),
+        ],
+    )
+    def test_normalizes_claim_shapes(self, factory, claim_value, expected):
+        request = _request(factory, claims={"permissions": claim_value})
+        view = _StubView(action="list", required_permissions=["catalog:read"])
+        # When the required perm is in the parsed set, permission is granted.
+        # We use this to indirectly verify normalization.
+        result = HasAPIPermission().has_permission(request, view)
+        assert result is ("catalog:read" in expected)
+
+    def test_missing_permissions_claim_is_empty(self, factory):
+        request = _request(factory, claims={"sub": "u1"})
+        view = _StubView(action="list", required_permissions=["catalog:read"])
+        assert HasAPIPermission().has_permission(request, view) is False
+
+    def test_request_auth_none_is_empty(self, factory):
+        request = _request(factory, claims=None)
+        view = _StubView(action="list", required_permissions=["catalog:read"])
+        assert HasAPIPermission().has_permission(request, view) is False
+
+    def test_request_auth_non_dict_is_empty(self, factory):
+        """Defensive: if auth ever becomes a non-dict, treat as no perms."""
+        request = _request(factory, claims="some-opaque-token")
+        view = _StubView(action="list", required_permissions=["catalog:read"])
+        assert HasAPIPermission().has_permission(request, view) is False
+
+
+# ---------------------------------------------------------------------------
+# required_permissions resolution
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredPermissionsResolution:
+    def test_no_required_permissions_passes(self, factory):
+        request = _request(factory, claims={"permissions": []})
+        view = _StubView(action="list", required_permissions=None)
+        assert HasAPIPermission().has_permission(request, view) is True
+
+    def test_empty_required_permissions_passes(self, factory):
+        request = _request(factory, claims={"permissions": []})
+        view = _StubView(action="list", required_permissions=[])
+        assert HasAPIPermission().has_permission(request, view) is True
+
+    def test_list_form_applies_to_all_actions(self, factory):
+        request = _request(
+            factory,
+            claims={"permissions": ["catalog:read"]},
+        )
+        view = _StubView(action="create", required_permissions=["catalog:read"])
+        assert HasAPIPermission().has_permission(request, view) is True
+
+    def test_string_form_treated_as_single_required_perm(self, factory):
+        request = _request(factory, claims={"permissions": ["catalog:read"]})
+        view = _StubView(action="list", required_permissions="catalog:read")
+        assert HasAPIPermission().has_permission(request, view) is True
+
+    def test_dict_form_dispatches_on_action(self, factory):
+        view = _StubView(
+            action="create",
+            required_permissions={
+                "list": ["catalog:read"],
+                "create": ["catalog:write"],
+            },
+        )
+        # Token has only read; create should be denied.
+        request = _request(factory, claims={"permissions": ["catalog:read"]})
+        assert HasAPIPermission().has_permission(request, view) is False
+
+        # Add write; create should pass.
+        request = _request(
+            factory,
+            claims={"permissions": ["catalog:read", "catalog:write"]},
+        )
+        assert HasAPIPermission().has_permission(request, view) is True
+
+    def test_dict_form_falls_back_to_default(self, factory):
+        view = _StubView(
+            action="merge_into",  # custom @action not in the map
+            required_permissions={
+                "list": ["catalog:read"],
+                "default": ["catalog:write"],
+            },
+        )
+        request = _request(factory, claims={"permissions": ["catalog:write"]})
+        assert HasAPIPermission().has_permission(request, view) is True
+
+    def test_unmapped_action_with_no_default_passes(self, factory):
+        """Actions absent from the dict and with no `default` aren't gated."""
+        view = _StubView(
+            action="custom",
+            required_permissions={"list": ["catalog:read"]},
+        )
+        request = _request(factory, claims={"permissions": []})
+        assert HasAPIPermission().has_permission(request, view) is True
+
+    def test_subset_match_required(self, factory):
+        """All required perms must be present, not just any of them."""
+        view = _StubView(
+            action="custom",
+            required_permissions=["catalog:read", "holdings:read"],
+        )
+        request = _request(factory, claims={"permissions": ["catalog:read"]})
+        assert HasAPIPermission().has_permission(request, view) is False
+
+        request = _request(
+            factory, claims={"permissions": ["catalog:read", "holdings:read"]}
+        )
+        assert HasAPIPermission().has_permission(request, view) is True
+
+
+# ---------------------------------------------------------------------------
+# Mixin wiring
+# ---------------------------------------------------------------------------
+
+
+class TestMixinWiring:
+    def test_catalog_mixin_attaches_class_and_map(self):
+        assert HasAPIPermission in CatalogPermissionMixin.permission_classes
+        assert CatalogPermissionMixin.required_permissions is CATALOG_PERMISSIONS
+
+    def test_holdings_mixin_attaches_class_and_map(self):
+        assert HasAPIPermission in HoldingsPermissionMixin.permission_classes
+        assert HoldingsPermissionMixin.required_permissions is HOLDINGS_PERMISSIONS
+
+    def test_catalog_map_covers_standard_actions(self):
+        for action in (
+            "list",
+            "retrieve",
+            "create",
+            "update",
+            "partial_update",
+            "destroy",
+        ):
+            assert action in CATALOG_PERMISSIONS
+        assert "default" in CATALOG_PERMISSIONS
+
+    def test_holdings_map_covers_standard_actions(self):
+        for action in (
+            "list",
+            "retrieve",
+            "create",
+            "update",
+            "partial_update",
+            "destroy",
+        ):
+            assert action in HOLDINGS_PERMISSIONS
+        assert "default" in HOLDINGS_PERMISSIONS
+
+    def test_league_viewset_inherits_catalog_mixin(self):
+        assert issubclass(LeagueViewSet, CatalogPermissionMixin)
+
+    def test_source_viewset_inherits_holdings_mixin(self):
+        assert issubclass(SourceViewSet, HoldingsPermissionMixin)
+
+
+# ---------------------------------------------------------------------------
+# Integration: enforcement against real viewsets
+# ---------------------------------------------------------------------------
+
+
+# Skip the auth class globally during these tests so request.auth is whatever
+# we attach via force_authenticate, not whatever JWKSAuthentication makes of
+# an empty header.
+_NO_AUTH = {"DEFAULT_AUTHENTICATION_CLASSES": []}
+
+
+def _force_auth(request, perms):
+    principal = JWTPrincipal(claims={"sub": "u1", "permissions": list(perms)})
+    force_authenticate(request, user=principal, token={"permissions": list(perms)})
+
+
+@pytest.mark.django_db
+@pytest.mark.enforce_api_permissions
+class TestEnforcementOnLeagueViewSet:
+    """Demonstrates ``catalog:read`` and ``catalog:write`` enforcement."""
+
+    def setup_method(self):
+        League.objects.create(short_name="NFL", long_name="NFL", level="PRO")
+
+    @override_settings(**_NO_AUTH)
+    def test_list_denied_without_catalog_read(self):
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        principal = JWTPrincipal(claims={"sub": "u1", "permissions": []})
+        client.force_authenticate(user=principal, token={"permissions": []})
+        response = client.get(reverse("league-list"))
+        assert response.status_code == 403
+
+    @override_settings(**_NO_AUTH)
+    def test_list_allowed_with_catalog_read(self):
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        principal = JWTPrincipal(
+            claims={"sub": "u1", "permissions": [Permissions.CATALOG_READ]}
+        )
+        client.force_authenticate(
+            user=principal, token={"permissions": [Permissions.CATALOG_READ]}
+        )
+        response = client.get(reverse("league-list"))
+        assert response.status_code == 200
+
+    @override_settings(**_NO_AUTH)
+    def test_create_denied_with_only_read(self):
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        principal = JWTPrincipal(
+            claims={"sub": "u1", "permissions": [Permissions.CATALOG_READ]}
+        )
+        client.force_authenticate(
+            user=principal, token={"permissions": [Permissions.CATALOG_READ]}
+        )
+        response = client.post(
+            reverse("league-list"),
+            {"short_name": "AAF", "long_name": "AAF", "level": "PRO"},
+            format="json",
+        )
+        assert response.status_code == 403
+
+    @override_settings(**_NO_AUTH)
+    def test_create_allowed_with_catalog_write(self):
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        perms = [Permissions.CATALOG_READ, Permissions.CATALOG_WRITE]
+        principal = JWTPrincipal(claims={"sub": "u1", "permissions": perms})
+        client.force_authenticate(user=principal, token={"permissions": perms})
+        response = client.post(
+            reverse("league-list"),
+            {"short_name": "AAF", "long_name": "AAF", "level": "PRO"},
+            format="json",
+        )
+        assert response.status_code == 201
+
+
+@pytest.mark.django_db
+@pytest.mark.enforce_api_permissions
+class TestEnforcementOnSourceViewSet:
+    """Demonstrates ``holdings:read`` and ``holdings:write`` enforcement."""
+
+    def setup_method(self):
+        Source.objects.create(name="Test Source", source_type="STREAMING")
+
+    @override_settings(**_NO_AUTH)
+    def test_list_denied_without_holdings_read(self):
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        principal = JWTPrincipal(
+            claims={"sub": "u1", "permissions": [Permissions.CATALOG_READ]}
+        )
+        client.force_authenticate(
+            user=principal, token={"permissions": [Permissions.CATALOG_READ]}
+        )
+        response = client.get(reverse("source-list"))
+        assert response.status_code == 403
+
+    @override_settings(**_NO_AUTH)
+    def test_list_allowed_with_holdings_read(self):
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        perms = [Permissions.HOLDINGS_READ]
+        principal = JWTPrincipal(claims={"sub": "u1", "permissions": perms})
+        client.force_authenticate(user=principal, token={"permissions": perms})
+        response = client.get(reverse("source-list"))
+        assert response.status_code == 200
+
+    @override_settings(**_NO_AUTH)
+    def test_destroy_denied_with_only_read(self):
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        source = Source.objects.first()
+        perms = [Permissions.HOLDINGS_READ]
+        principal = JWTPrincipal(claims={"sub": "u1", "permissions": perms})
+        client.force_authenticate(user=principal, token={"permissions": perms})
+        response = client.delete(reverse("source-detail", args=[source.pk]))
+        assert response.status_code == 403
+
+    @override_settings(**_NO_AUTH)
+    def test_destroy_allowed_with_holdings_write(self):
+        from rest_framework.test import APIClient
+
+        client = APIClient()
+        source = Source.objects.first()
+        perms = [Permissions.HOLDINGS_READ, Permissions.HOLDINGS_WRITE]
+        principal = JWTPrincipal(claims={"sub": "u1", "permissions": perms})
+        client.force_authenticate(user=principal, token={"permissions": perms})
+        response = client.delete(reverse("source-detail", args=[source.pk]))
+        assert response.status_code == 204


### PR DESCRIPTION
## Summary

- Adds the initial API permission catalog (`catalog:read`, `catalog:write`, `holdings:read`, `holdings:write`) under the `resource:verb` naming convention.
- Implements `gam.auth.permissions.HasAPIPermission` plus `CatalogPermissionMixin`/`HoldingsPermissionMixin` for declarative per-viewset enforcement.
- Wires the mixins into every existing API viewset (catalog and holdings domains).
- Documents the catalog, naming rationale, and the manual Clerk JWT-template task at `docs/auth/permissions.md`.

## Implementation notes

- The permission class accepts both list-form and space-delimited string-form `permissions` claims (matches OAuth scope conventions).
- `required_permissions` may be a list/tuple/string (applies to all actions) or a dict keyed by DRF action with a `"default"` fallback for custom `@action` methods.
- A `tests/conftest.py` autouse fixture bypasses enforcement for the existing API test suite (which authenticates anonymously); tests in `tests/test_api_permissions.py` opt back into real enforcement via the `enforce_api_permissions` marker.
- Per-object permissions are explicitly out of scope; called out in the docs as a follow-up once access patterns stabilize.

## Test plan

- [x] `uv run pytest` — 616 passed (31 new, all preexisting still green)
- [x] `uv run ruff check .` and `uv run ruff format .` clean
- [x] Each of the four catalog entries has at least one viewset enforcing it (per AC #4)
- [ ] Manual: configure Clerk JWT template's `permissions` claim before this lands in any environment that uses real Clerk tokens (see "JWT template (Clerk)" section in `docs/auth/permissions.md`).

Closes #316