### PR TITLE
feat(GAM #319): add integration tests for JWT and API key auth paths

### DIFF
--- a/gam/auth/jwt.py
+++ b/gam/auth/jwt.py
@@ -100,9 +100,23 @@ class JWKSAuthentication(authentication.BaseAuthentication):
         token = self._extract_bearer_token(request)
         if token is None:
             return None
+        if not self._looks_like_jwt(token):
+            # Let other auth classes (e.g. APIKeyAuthentication) handle it.
+            return None
 
         claims = self._decode_token(token)
         return (JWTPrincipal(claims=claims), claims)
+
+    @staticmethod
+    def _looks_like_jwt(token: str) -> bool:
+        """Cheap shape check: a JWT is exactly ``header.payload.signature``.
+
+        Returning ``False`` here yields ``None`` from ``authenticate`` so DRF
+        falls through to the next configured authentication class instead of
+        rejecting the request as a malformed JWT. Without this, a valid API
+        key like ``grd_live_<hex>`` would be eaten by the JWT class.
+        """
+        return token.count(".") == 2
 
     def authenticate_header(self, request: Any) -> str:
         return self.keyword

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,4 +88,5 @@ python_functions = ["test_*"]
 addopts = "--no-migrations"
 markers = [
     "enforce_api_permissions: do not bypass HasAPIPermission for this test",
+    "smoke: live external-dependency smoke test; skipped unless explicitly opted in",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,15 @@ from __future__ import annotations
 
 import pytest
 
+# Re-export reusable auth factories so any test module gets them via
+# pytest's standard fixture discovery (no per-file import needed).
+from tests.fixtures.auth import (  # noqa: F401
+    jwks_harness,
+    make_account,
+    make_api_key,
+    mint_jwt,
+)
+
 
 @pytest.fixture(autouse=True)
 def _bypass_api_permissions(request, monkeypatch):

--- a/tests/fixtures/auth.py
+++ b/tests/fixtures/auth.py
@@ -1,0 +1,206 @@
+"""
+Reusable authentication fixtures and factories (TGF-319).
+
+Used by the integration test suite under ``tests/test_auth_integration.py``
+and intentionally exposed for any future story that needs to mint a valid
+RS256 JWT or an API key against the local test harness. Built on top of
+:mod:`scripts.local_jwks_server` (introduced in TGF-313) so the same
+JWKS-issuance machinery backs both end-to-end and integration tests.
+
+Design goals:
+
+* **One JWKS server per session.** Spinning up an HTTP server on every test
+  is slow; a session-scoped fixture keeps it alive and reuses its keypair.
+* **Parameterized claim minting.** Every JWT field that can vary in real
+  traffic (audience, issuer, expiry, ``permissions``, ``azp``) is
+  overridable from the call site so individual tests can shape edge cases
+  without re-implementing the encoder.
+* **Account + API-key factories.** Fixtures return callables (factories)
+  rather than single instances so a single test can compose multiple
+  accounts/keys without fixture duplication.
+"""
+
+from __future__ import annotations
+
+import socket
+from collections.abc import Callable, Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any, NamedTuple
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from django.contrib.auth import get_user_model
+
+from gam.accounts.models import APIKey, APIKeyEnvironment, ClerkAccount
+from gam.auth.api_key import generate_api_key
+from gam.auth.jwt import _get_jwks_client
+from scripts.local_jwks_server import _issue_token, serve
+
+DEFAULT_KID = "test-fixture-kid"
+DEFAULT_ISSUER = "https://issuer.test.griddy"
+DEFAULT_AUDIENCE = "griddy-api-test"
+
+
+class JWKSHarness(NamedTuple):
+    """Bundle of values describing a running fake JWKS server."""
+
+    jwks_url: str
+    issuer: str
+    audience: str
+    kid: str
+    private_key: rsa.RSAPrivateKey
+
+
+def _free_port() -> int:
+    """Return an ephemeral port — avoids fixture conflicts in xdist runs."""
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(scope="session")
+def jwks_harness() -> Iterator[JWKSHarness]:
+    """Run a JWKS server for the test session and yield its endpoints + key.
+
+    Session scope means one process-wide HTTP server, reused by every
+    test. The :class:`PyJWKClient` cache inside
+    :mod:`gam.auth.jwt` is cleared on entry so the harness URL takes
+    effect even if a prior test bound a different one.
+    """
+    port = _free_port()
+    server, private_key = serve("127.0.0.1", port, kid=DEFAULT_KID)
+    _get_jwks_client.cache_clear()
+    try:
+        yield JWKSHarness(
+            jwks_url=f"http://127.0.0.1:{port}/.well-known/jwks.json",
+            issuer=DEFAULT_ISSUER,
+            audience=DEFAULT_AUDIENCE,
+            kid=DEFAULT_KID,
+            private_key=private_key,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        _get_jwks_client.cache_clear()
+
+
+@pytest.fixture
+def mint_jwt(jwks_harness: JWKSHarness) -> Callable[..., str]:
+    """Return a callable that mints RS256 JWTs against the harness.
+
+    All claims have sensible defaults; pass overrides as keyword args:
+
+    .. code-block:: python
+
+        token = mint_jwt(sub="user_123", permissions=["catalog:read"])
+        token = mint_jwt(audience="other-api")  # wrong-audience case
+        token = mint_jwt(ttl_seconds=-60)        # expired-token case
+    """
+
+    def _mint(
+        *,
+        sub: str = "user_test",
+        audience: str | None = None,
+        issuer: str | None = None,
+        ttl_seconds: int = 3600,
+        permissions: list[str] | None = None,
+        azp: str | None = None,
+        email: str | None = None,
+        kid: str | None = None,
+        extra_claims: dict[str, Any] | None = None,
+    ) -> str:
+        claims: dict[str, Any] = {}
+        if permissions is not None:
+            claims["permissions"] = permissions
+        if azp is not None:
+            claims["azp"] = azp
+        if email is not None:
+            claims["email"] = email
+        if extra_claims:
+            claims.update(extra_claims)
+
+        # Negative TTL produces an already-expired token. The harness
+        # ``_issue_token`` helper computes ``exp`` from ``now + ttl`` so
+        # this works directly without special-casing.
+        return _issue_token(
+            jwks_harness.private_key,
+            kid=kid or jwks_harness.kid,
+            issuer=issuer or jwks_harness.issuer,
+            audience=audience or jwks_harness.audience,
+            subject=sub,
+            ttl_seconds=ttl_seconds,
+            extra_claims=claims,
+        )
+
+    return _mint
+
+
+@pytest.fixture
+def make_account() -> Callable[..., ClerkAccount]:
+    """Return a factory for ``(User, ClerkAccount)`` pairs.
+
+    Each call creates a fresh user with a unique username; the returned
+    :class:`ClerkAccount` is what most auth-related tests want to attach
+    API keys to.
+    """
+    User = get_user_model()
+    counter = {"n": 0}
+
+    def _make(
+        *,
+        sub: str | None = None,
+        email: str | None = None,
+    ) -> ClerkAccount:
+        counter["n"] += 1
+        n = counter["n"]
+        return ClerkAccount.objects.create(
+            user=User.objects.create_user(
+                username=f"fixture-user-{n}",
+                email=email or f"u{n}@griddy.test",
+            ),
+            clerk_sub=sub or f"user_fixture_{n}",
+            email=email or f"u{n}@griddy.test",
+        )
+
+    return _make
+
+
+@pytest.fixture
+def make_api_key() -> Callable[..., tuple[APIKey, str]]:
+    """Return a factory that mints API keys against an existing account.
+
+    Yields ``(api_key_row, plaintext)``. Callers pass the plaintext as
+    ``Authorization: Bearer <plaintext>`` to exercise the live auth path.
+    """
+
+    def _make(
+        account: ClerkAccount,
+        *,
+        name: str = "fixture-key",
+        environment: str = APIKeyEnvironment.LIVE,
+        scopes: list[str] | None = None,
+        expires_at: datetime | None = None,
+    ) -> tuple[APIKey, str]:
+        return generate_api_key(
+            account,
+            name=name,
+            environment=environment,
+            scopes=scopes,
+            expires_at=expires_at,
+        )
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Helpers re-exported for tests that prefer module-level imports
+# ---------------------------------------------------------------------------
+
+
+def in_n_seconds(n: int) -> datetime:
+    """Return a tz-aware datetime ``n`` seconds in the future.
+
+    Convenience wrapper to keep test bodies readable when expressing
+    expiry windows for API keys.
+    """
+    return datetime.now(UTC) + timedelta(seconds=n)

--- a/tests/test_auth_clerk_live.py
+++ b/tests/test_auth_clerk_live.py
@@ -1,0 +1,112 @@
+"""
+Live smoke test against the real Clerk dev instance (TGF-319).
+
+Skipped by default. Enable by setting ``CLERK_LIVE_SMOKE=1`` and the four
+required env vars listed below. Intended for a nightly CI job, not the
+per-PR pytest run — it makes outbound calls to Clerk's Backend API and
+depends on the dev instance staying configured.
+
+Required environment variables when ``CLERK_LIVE_SMOKE=1``:
+
+* ``CLERK_LIVE_SECRET_KEY``     — Clerk Backend API secret (sk_test_…).
+* ``CLERK_LIVE_USER_ID``        — A pre-created user_… ID to mint a token for.
+* ``CLERK_LIVE_JWKS_URL``       — JWKS endpoint of the same Clerk instance.
+* ``CLERK_LIVE_ISSUER``         — ``iss`` claim Clerk emits.
+* ``CLERK_LIVE_AUDIENCE``       — ``aud`` claim Clerk emits (or session
+  audience if you customized it).
+
+The test mints a session token via the Backend API, points Django at the
+matching JWKS URL, and confirms a representative endpoint returns 200.
+A failure here means either the env is misconfigured (likely) or Clerk
+changed something we depend on (rare but worth catching).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import requests
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+CLERK_API_BASE = "https://api.clerk.com/v1"
+
+pytestmark = [pytest.mark.django_db, pytest.mark.smoke]
+
+
+def _required_env() -> dict[str, str] | None:
+    keys = (
+        "CLERK_LIVE_SECRET_KEY",
+        "CLERK_LIVE_USER_ID",
+        "CLERK_LIVE_JWKS_URL",
+        "CLERK_LIVE_ISSUER",
+        "CLERK_LIVE_AUDIENCE",
+    )
+    values = {k: os.getenv(k, "") for k in keys}
+    if any(not v for v in values.values()):
+        return None
+    return values
+
+
+@pytest.fixture
+def live_env() -> dict[str, str]:
+    if os.getenv("CLERK_LIVE_SMOKE") != "1":
+        pytest.skip("CLERK_LIVE_SMOKE=1 not set; skipping live Clerk smoke test.")
+    env = _required_env()
+    if env is None:
+        pytest.skip("Required CLERK_LIVE_* env vars not configured.")
+    return env
+
+
+def _mint_session_token(secret_key: str, user_id: str) -> str:
+    headers = {
+        "Authorization": f"Bearer {secret_key}",
+        "Content-Type": "application/json",
+    }
+    session = requests.post(
+        f"{CLERK_API_BASE}/sessions",
+        headers=headers,
+        json={"user_id": user_id},
+        timeout=10,
+    )
+    session.raise_for_status()
+    session_id = session.json()["id"]
+
+    token = requests.post(
+        f"{CLERK_API_BASE}/sessions/{session_id}/tokens",
+        headers=headers,
+        timeout=10,
+    )
+    token.raise_for_status()
+    return token.json()["jwt"]
+
+
+def test_live_clerk_token_authorizes_against_local_django(live_env):
+    """Mint a token from the live Clerk dev instance, hit a real endpoint."""
+    token = _mint_session_token(
+        live_env["CLERK_LIVE_SECRET_KEY"],
+        live_env["CLERK_LIVE_USER_ID"],
+    )
+
+    from gam.auth.jwt import _get_jwks_client
+
+    _get_jwks_client.cache_clear()
+    with override_settings(
+        JWKS_URL=live_env["CLERK_LIVE_JWKS_URL"],
+        JWT_ISSUER=live_env["CLERK_LIVE_ISSUER"],
+        JWT_AUDIENCE=live_env["CLERK_LIVE_AUDIENCE"],
+        JWT_AUTHORIZED_PARTIES=[],
+    ):
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+        response = client.get(reverse("league-list"))
+
+    # 200 if the configured Clerk user has catalog:read; 403 if not. Either
+    # outcome proves the JWT validated against the JWKS (a 401 would mean
+    # the dev instance JWKS / issuer / audience drifted from what we set).
+    assert response.status_code in {200, 403}, (
+        f"Unexpected {response.status_code} from live Clerk smoke test; "
+        "JWKS / issuer / audience likely drifted."
+    )

--- a/tests/test_auth_integration.py
+++ b/tests/test_auth_integration.py
@@ -1,0 +1,303 @@
+"""
+End-to-end integration tests for both auth paths (TGF-319).
+
+Where the unit suites under ``tests/test_jwks_auth.py`` and
+``tests/test_api_key_auth.py`` exercise individual classes in isolation,
+this module drives requests through the full DRF stack — routing, both
+authentication classes wired into ``DEFAULT_AUTHENTICATION_CLASSES``,
+:class:`HasAPIPermission`, and the catalog/holdings viewsets — to confirm
+the pieces compose correctly.
+
+Test matrix (x = covered):
+
+| Path / case        | 200  | 401  | 403  |
+|--------------------|------|------|------|
+| JWT happy          |  x   |      |      |
+| JWT no header      |      |  x   |      |
+| JWT missing perm   |      |      |  x   |
+| JWT expired        |      |  x   |      |
+| JWT wrong audience |      |  x   |      |
+| JWT wrong issuer   |      |  x   |      |
+| JWT azp mismatch   |      |  x   |      |
+| API key happy      |  x   |      |      |
+| API key missing    |      |      |  x   |
+| API key revoked    |      |  x   |      |
+| API key expired    |      |  x   |      |
+| API key malformed  |      |  x   |      |
+| API key unknown    |      |  x   |      |
+| Cross-domain perm  |      |      |  x   |
+| Both classes wired |  x   |      |      |  (one request via each path)
+
+The matrix targets ``LeagueViewSet`` (catalog) and ``SourceViewSet``
+(holdings) as representative endpoints. Coverage of every viewset would
+be redundant — :class:`HasAPIPermission` is shared, so the same answer
+applies everywhere.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from gam.accounts.models import APIKeyEnvironment
+from gam.auth.permissions import Permissions
+
+pytestmark = [pytest.mark.django_db, pytest.mark.enforce_api_permissions]
+
+
+# ---------------------------------------------------------------------------
+# Settings overrides
+# ---------------------------------------------------------------------------
+
+
+def _settings_for(jwks_harness):
+    """Build the override_settings kwargs for a configured JWKS harness."""
+    return {
+        "JWKS_URL": jwks_harness.jwks_url,
+        "JWT_ISSUER": jwks_harness.issuer,
+        "JWT_AUDIENCE": jwks_harness.audience,
+        "JWT_AUTHORIZED_PARTIES": [],  # off by default; specific tests opt in
+        "DEFAULT_AUTHENTICATION_CLASSES": (
+            "gam.auth.jwt.JWKSAuthentication",
+            "gam.auth.api_key.APIKeyAuthentication",
+        ),
+    }
+
+
+@pytest.fixture
+def configured(jwks_harness):
+    """Apply harness-aware settings for the duration of the test."""
+    with override_settings(
+        **{
+            "JWKS_URL": jwks_harness.jwks_url,
+            "JWT_ISSUER": jwks_harness.issuer,
+            "JWT_AUDIENCE": jwks_harness.audience,
+            "JWT_AUTHORIZED_PARTIES": [],
+        }
+    ):
+        # Force the cached PyJWKClient to re-resolve against the harness URL
+        # in case a prior test bound a different one.
+        from gam.auth.jwt import _get_jwks_client
+
+        _get_jwks_client.cache_clear()
+        yield
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+def _bearer(client: APIClient, token: str) -> APIClient:
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+    return client
+
+
+# ---------------------------------------------------------------------------
+# JWT path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("configured")
+class TestJWTAuthPath:
+    def test_happy_path_list_with_catalog_read(self, client, mint_jwt):
+        token = mint_jwt(permissions=[Permissions.CATALOG_READ])
+        response = _bearer(client, token).get(reverse("league-list"))
+        assert response.status_code == 200
+
+    def test_no_header_returns_401(self, client):
+        response = client.get(reverse("league-list"))
+        assert response.status_code == 401
+
+    def test_missing_permission_returns_403(self, client, mint_jwt):
+        token = mint_jwt(permissions=[Permissions.HOLDINGS_READ])
+        response = _bearer(client, token).get(reverse("league-list"))
+        assert response.status_code == 403
+
+    def test_expired_token_returns_401(self, client, mint_jwt):
+        token = mint_jwt(permissions=[Permissions.CATALOG_READ], ttl_seconds=-60)
+        response = _bearer(client, token).get(reverse("league-list"))
+        assert response.status_code == 401
+
+    def test_wrong_audience_returns_401(self, client, mint_jwt):
+        token = mint_jwt(
+            audience="some-other-api",
+            permissions=[Permissions.CATALOG_READ],
+        )
+        response = _bearer(client, token).get(reverse("league-list"))
+        assert response.status_code == 401
+
+    def test_wrong_issuer_returns_401(self, client, mint_jwt):
+        token = mint_jwt(
+            issuer="https://evil.example",
+            permissions=[Permissions.CATALOG_READ],
+        )
+        response = _bearer(client, token).get(reverse("league-list"))
+        assert response.status_code == 401
+
+    def test_azp_mismatch_returns_401(self, jwks_harness, client, mint_jwt):
+        token = mint_jwt(
+            permissions=[Permissions.CATALOG_READ],
+            azp="http://evil.example",
+        )
+        with override_settings(
+            JWT_AUTHORIZED_PARTIES=["http://localhost:3000"],
+        ):
+            response = _bearer(client, token).get(reverse("league-list"))
+        assert response.status_code == 401
+
+    def test_write_requires_catalog_write(self, client, mint_jwt):
+        read_only = mint_jwt(permissions=[Permissions.CATALOG_READ])
+        response = _bearer(client, read_only).post(
+            reverse("league-list"),
+            {"short_name": "AAF", "long_name": "AAF", "level": "PRO"},
+            format="json",
+        )
+        assert response.status_code == 403
+
+    def test_write_succeeds_with_catalog_write(self, client, mint_jwt):
+        token = mint_jwt(
+            permissions=[Permissions.CATALOG_READ, Permissions.CATALOG_WRITE]
+        )
+        response = _bearer(client, token).post(
+            reverse("league-list"),
+            {"short_name": "AAF", "long_name": "AAF", "level": "PRO"},
+            format="json",
+        )
+        assert response.status_code == 201
+
+
+# ---------------------------------------------------------------------------
+# API key path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("configured")
+class TestAPIKeyAuthPath:
+    def test_happy_path_list_with_catalog_read(
+        self, client, make_account, make_api_key
+    ):
+        account = make_account()
+        _, plaintext = make_api_key(account, scopes=[Permissions.CATALOG_READ])
+        response = _bearer(client, plaintext).get(reverse("league-list"))
+        assert response.status_code == 200
+
+    def test_missing_scope_returns_403(self, client, make_account, make_api_key):
+        account = make_account()
+        _, plaintext = make_api_key(account, scopes=[Permissions.HOLDINGS_READ])
+        response = _bearer(client, plaintext).get(reverse("league-list"))
+        assert response.status_code == 403
+
+    def test_revoked_key_returns_401(self, client, make_account, make_api_key):
+        account = make_account()
+        api_key, plaintext = make_api_key(account, scopes=[Permissions.CATALOG_READ])
+        api_key.revoked_at = timezone.now()
+        api_key.save(update_fields=["revoked_at"])
+        response = _bearer(client, plaintext).get(reverse("league-list"))
+        assert response.status_code == 401
+
+    def test_expired_key_returns_401(self, client, make_account, make_api_key):
+        account = make_account()
+        api_key, plaintext = make_api_key(account, scopes=[Permissions.CATALOG_READ])
+        api_key.expires_at = timezone.now() - timedelta(seconds=1)
+        api_key.save(update_fields=["expires_at"])
+        response = _bearer(client, plaintext).get(reverse("league-list"))
+        assert response.status_code == 401
+
+    def test_malformed_key_returns_401(self, client):
+        response = _bearer(client, "grd_live_not-hex").get(reverse("league-list"))
+        assert response.status_code == 401
+
+    def test_unknown_key_returns_401(self, client):
+        # Right shape, never minted — passes regex, fails hash compare.
+        token = "grd_live_" + "0" * 48
+        response = _bearer(client, token).get(reverse("league-list"))
+        assert response.status_code == 401
+
+    def test_test_environment_key_works(self, client, make_account, make_api_key):
+        account = make_account()
+        _, plaintext = make_api_key(
+            account,
+            environment=APIKeyEnvironment.TEST,
+            scopes=[Permissions.CATALOG_READ],
+        )
+        assert plaintext.startswith("grd_test_")
+        response = _bearer(client, plaintext).get(reverse("league-list"))
+        assert response.status_code == 200
+
+    def test_write_requires_catalog_write(self, client, make_account, make_api_key):
+        account = make_account()
+        _, plaintext = make_api_key(account, scopes=[Permissions.CATALOG_READ])
+        response = _bearer(client, plaintext).post(
+            reverse("league-list"),
+            {"short_name": "USFL", "long_name": "USFL", "level": "PRO"},
+            format="json",
+        )
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Cross-domain enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("configured")
+class TestCrossDomainEnforcement:
+    """Catalog scopes must not grant holdings access (and vice versa)."""
+
+    def test_catalog_read_does_not_grant_holdings(self, client, mint_jwt):
+        token = mint_jwt(permissions=[Permissions.CATALOG_READ])
+        response = _bearer(client, token).get(reverse("source-list"))
+        assert response.status_code == 403
+
+    def test_holdings_read_does_not_grant_catalog(
+        self, client, make_account, make_api_key
+    ):
+        account = make_account()
+        _, plaintext = make_api_key(account, scopes=[Permissions.HOLDINGS_READ])
+        response = _bearer(client, plaintext).get(reverse("league-list"))
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Coexistence: both auth classes installed simultaneously
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("configured")
+class TestAuthClassCoexistence:
+    """Same endpoint must accept JWT or API key depending on the bearer scheme."""
+
+    def test_jwt_and_api_key_both_authorize_same_endpoint(
+        self, client, mint_jwt, make_account, make_api_key
+    ):
+        account = make_account()
+        _, plaintext = make_api_key(account, scopes=[Permissions.CATALOG_READ])
+        jwt = mint_jwt(permissions=[Permissions.CATALOG_READ])
+
+        # JWT path
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {jwt}")
+        assert client.get(reverse("league-list")).status_code == 200
+
+        # Switch credentials and try again — same endpoint, same expected
+        # outcome, different auth class on the server side.
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {plaintext}")
+        assert client.get(reverse("league-list")).status_code == 200
+
+    def test_grd_prefix_routes_to_api_key_class_only(
+        self, client, make_account, make_api_key
+    ):
+        """An invalid ``grd_*`` token must not silently fall through to JWKS."""
+        account = make_account()
+        make_api_key(account, scopes=[Permissions.CATALOG_READ])
+        # Garbage that happens to start with ``grd_`` — JWT path would treat
+        # this as malformed input too, but we want to confirm API key auth
+        # is what produces the 401.
+        bad = "grd_live_" + "z" * 48  # invalid hex
+        response = _bearer(client, bad).get(reverse("league-list"))
+        assert response.status_code == 401

--- a/tests/test_jwks_auth.py
+++ b/tests/test_jwks_auth.py
@@ -258,8 +258,22 @@ class TestInvalidTokens:
         ):
             JWKSAuthentication().authenticate(request)
 
-    def test_malformed_token_rejected(self, factory, rsa_keypair):
+    def test_non_jwt_shape_returns_none(self, factory, rsa_keypair):
+        """Tokens that don't look like JWTs are passed to the next auth class.
+
+        After TGF-319, JWKSAuthentication only owns tokens with the
+        ``header.payload.signature`` shape. Anything else (API keys,
+        garbage) returns ``None`` so DRF can try the next class.
+        """
         request = factory.get("/", HTTP_AUTHORIZATION="Bearer not-a-real-jwt")
+
+        with _patch_signing_key(rsa_keypair.public_key()):
+            assert JWKSAuthentication().authenticate(request) is None
+
+    def test_jwt_shape_but_garbage_payload_rejected(self, factory, rsa_keypair):
+        """Tokens shaped like JWTs (3 dot-separated parts) are still rejected
+        when they fail to decode."""
+        request = factory.get("/", HTTP_AUTHORIZATION="Bearer not.a.realjwt")
 
         with (
             _patch_signing_key(rsa_keypair.public_key()),


### PR DESCRIPTION
## Summary

- Adds reusable session-scoped auth fixtures (`jwks_harness`, `mint_jwt`, `make_account`, `make_api_key`) under `tests/fixtures/auth.py`, exposed via `tests/conftest.py` for any future story to consume.
- Adds `tests/test_auth_integration.py` — a 21-test end-to-end matrix that drives both auth classes through the full DRF stack against representative catalog and holdings viewsets.
- Adds `tests/test_auth_clerk_live.py` — a gated smoke test (`pytest -m smoke` + `CLERK_LIVE_SMOKE=1` + creds) that mints a token from the real Clerk dev instance and confirms it authorizes against local Django. Skipped by default; intended for nightly CI.
- Registers a new `smoke` pytest marker in `pyproject.toml`.

## Bug fix uncovered while writing tests

The integration matrix surfaced a real production bug from TGF-318:
`JWKSAuthentication.authenticate()` was raising `AuthenticationFailed` on `grd_*` API key tokens instead of returning `None`. With JWKS first in `DEFAULT_AUTHENTICATION_CLASSES`, every API key request was being rejected with 401 before `APIKeyAuthentication` ever saw it.

Fix: added `_looks_like_jwt(token)` (cheap "exactly two dots" shape check). When the token doesn't look like a JWT, the class returns `None` so DRF falls through to the next auth class. Updated the corresponding unit test to reflect the new contract — malformed-but-shaped-like-a-JWT (`not.a.realjwt`) still raises; non-JWT-shaped tokens (`not-a-real-jwt`, API keys) return `None`.

This was invisible to the unit tests in `test_api_key_auth.py` because they instantiated `APIKeyAuthentication` directly, bypassing DRF's normal class iteration. Exactly the gap integration tests are supposed to catch.

## Test matrix

| Path / case        | 200 | 401 | 403 |
|--------------------|-----|-----|-----|
| JWT happy          |  x  |     |     |
| JWT no header      |     |  x  |     |
| JWT missing perm   |     |     |  x  |
| JWT expired        |     |  x  |     |
| JWT wrong audience |     |  x  |     |
| JWT wrong issuer   |     |  x  |     |
| JWT azp mismatch   |     |  x  |     |
| JWT write w/o write scope |     |     |  x  |
| JWT write w/ write scope  |  x (201)  |     |     |
| API key happy      |  x  |     |     |
| API key missing scope |    |     |  x  |
| API key revoked    |     |  x  |     |
| API key expired    |     |  x  |     |
| API key malformed  |     |  x  |     |
| API key unknown    |     |  x  |     |
| API key test env   |  x  |     |     |
| API key write w/o write scope |    |     |  x  |
| Catalog scope on holdings endpoint |    |     |  x  |
| Holdings scope on catalog endpoint |    |     |  x  |
| Both classes wired (JWT request) |  x  |     |     |
| Both classes wired (API key request) |  x  |     |     |
| `grd_` invalid → API key path owns the 401 | | x | |

## Implementation notes

- **Session-scoped JWKS server.** One HTTP server runs for the entire pytest session. The `_get_jwks_client` lru_cache is cleared on entry so other tests' bindings can't leak in.
- **Parameterized `mint_jwt`.** Every JWT field that can vary in real traffic (audience, issuer, expiry, `permissions`, `azp`, `email`, `kid`, arbitrary extras) is overridable from the call site. Negative `ttl_seconds` produces an already-expired token — no special-casing needed.
- **`make_account` and `make_api_key` are factories**, not fixtures returning a single instance, so a single test can compose multiple accounts/keys without fixture duplication.
- **Smoke test gating.** `pytest.mark.smoke` + `CLERK_LIVE_SMOKE=1` + 5 required env vars. Default `pytest` invocation skips it; CI nightly job would do `pytest -m smoke` with the env wired.

## Test plan

- [x] `uv run pytest` — 688 passed, 1 skipped (the gated smoke test)
- [x] `uv run ruff check .` and `uv run ruff format .` clean
- [x] CI runs the new integration tests on every PR via the existing `quality-gates.yml` workflow (no CI changes needed; pytest discovers them automatically)

## Manual follow-ups (optional)

- **Set up the nightly Clerk smoke job** when ready: a separate workflow with `pytest -m smoke` and the 5 `CLERK_LIVE_*` env vars wired from secrets. I didn't add this workflow because the right cadence/scope is a deployment decision.

Closes #319