### PR TITLE
feat(GAM): add local Miniflare R2 uploader for cost-free HLS PoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,7 @@ cython_debug/
 creds.json
 busted.json
 .claude/claude-session-setup.sh
+
+# Local wrangler/Miniflare state from `wrangler r2 object put --local` etc.
+# (created when running package_hls --local from this repo root).
+.wrangler/

--- a/archive/management/commands/package_hls.py
+++ b/archive/management/commands/package_hls.py
@@ -109,6 +109,16 @@ class Command(BaseCommand):
                 "Default 8. Set to 1 for sequential, debug-friendly behavior."
             ),
         )
+        parser.add_argument(
+            "--local-max-attempts",
+            type=int,
+            default=3,
+            help=(
+                "Retry attempts per `wrangler r2 object put` invocation when "
+                "--local (covers transient workerd/SQLite/network hiccups). "
+                "Default 3. Set to 1 to disable retries."
+            ),
+        )
 
     def handle(self, *args, **options) -> None:
         roots = self._resolve_roots(options["roots"])
@@ -187,6 +197,7 @@ class Command(BaseCommand):
             command=shlex.split(options["wrangler_cmd"]),
             cwd=options["wrangler_cwd"],
             max_workers=options["local_workers"],
+            max_attempts=options["local_max_attempts"],
         )
 
     def _report(self, summary, *, dry_run: bool) -> None:

--- a/archive/management/commands/package_hls.py
+++ b/archive/management/commands/package_hls.py
@@ -18,6 +18,7 @@ Examples::
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 
 from django.conf import settings
@@ -25,7 +26,11 @@ from django.core.management.base import BaseCommand, CommandError
 
 from archive.packaging import PackagingPipeline
 from archive.packaging.packager import DEFAULT_SEGMENT_DURATION
-from archive.packaging.uploader import InMemoryUploader, R2Uploader
+from archive.packaging.uploader import (
+    InMemoryUploader,
+    R2Uploader,
+    WranglerLocalUploader,
+)
 
 
 class Command(BaseCommand):
@@ -60,20 +65,63 @@ class Command(BaseCommand):
             action="store_true",
             help="Probe and package locally but upload nothing to R2.",
         )
+        parser.add_argument(
+            "--local",
+            action="store_true",
+            help=(
+                "Load packaged output into the local Miniflare R2 store via "
+                "`wrangler r2 object put --local` (the cost-free PoC path, "
+                "ADR-0008) instead of uploading to real R2."
+            ),
+        )
+        parser.add_argument(
+            "--bucket",
+            default=None,
+            help="R2 bucket name for --local (defaults to settings.R2_BUCKET).",
+        )
+        parser.add_argument(
+            "--persist-to",
+            default=None,
+            help=(
+                "Miniflare persistence directory for --local. Must match the "
+                "`wrangler dev --persist-to` value (default .wrangler/state)."
+            ),
+        )
+        parser.add_argument(
+            "--wrangler-cmd",
+            default="npx wrangler",
+            help='Command used to invoke wrangler for --local (default "npx wrangler").',
+        )
+        parser.add_argument(
+            "--wrangler-cwd",
+            default=None,
+            help=(
+                "Directory to run wrangler from for --local — the Worker project "
+                "(TGF-361) — so its config and local persistence align."
+            ),
+        )
 
     def handle(self, *args, **options) -> None:
         roots = self._resolve_roots(options["roots"])
         dry_run: bool = options["dry_run"]
+        local: bool = options["local"]
         segment_duration: int = options["segment_duration"]
         if segment_duration <= 0:
             raise CommandError("--segment-duration must be a positive integer.")
+        if dry_run and local:
+            raise CommandError("--dry-run and --local are mutually exclusive.")
 
-        uploader = InMemoryUploader() if dry_run else self._build_r2_uploader()
+        if dry_run:
+            uploader = InMemoryUploader()
+            target = "dry run, no upload"
+        elif local:
+            uploader = self._build_local_uploader(options)
+            target = "loading into local R2 (Miniflare)"
+        else:
+            uploader = self._build_r2_uploader()
+            target = "uploading to R2"
 
-        self.stdout.write(
-            f"Packaging {len(roots)} root(s) "
-            f"({'dry run, no upload' if dry_run else 'uploading to R2'})…"
-        )
+        self.stdout.write(f"Packaging {len(roots)} root(s) ({target})…")
         pipeline = PackagingPipeline(
             uploader, segment_duration=segment_duration, dry_run=dry_run
         )
@@ -112,6 +160,19 @@ class Command(BaseCommand):
             endpoint_url=settings.R2_ENDPOINT_URL,
             access_key_id=settings.R2_ACCESS_KEY_ID,
             secret_access_key=settings.R2_SECRET_ACCESS_KEY,
+        )
+
+    def _build_local_uploader(self, options) -> WranglerLocalUploader:
+        bucket = options["bucket"] or getattr(settings, "R2_BUCKET", None)
+        if not bucket:
+            raise CommandError(
+                "--local needs a bucket name; pass --bucket or set R2_BUCKET."
+            )
+        return WranglerLocalUploader(
+            bucket=bucket,
+            persist_to=options["persist_to"],
+            command=shlex.split(options["wrangler_cmd"]),
+            cwd=options["wrangler_cwd"],
         )
 
     def _report(self, summary, *, dry_run: bool) -> None:

--- a/archive/management/commands/package_hls.py
+++ b/archive/management/commands/package_hls.py
@@ -100,6 +100,15 @@ class Command(BaseCommand):
                 "(TGF-361) — so its config and local persistence align."
             ),
         )
+        parser.add_argument(
+            "--local-workers",
+            type=int,
+            default=8,
+            help=(
+                "Parallel `wrangler r2 object put` calls per game when --local. "
+                "Default 8. Set to 1 for sequential, debug-friendly behavior."
+            ),
+        )
 
     def handle(self, *args, **options) -> None:
         roots = self._resolve_roots(options["roots"])
@@ -125,7 +134,11 @@ class Command(BaseCommand):
         pipeline = PackagingPipeline(
             uploader, segment_duration=segment_duration, dry_run=dry_run
         )
-        summary = pipeline.run(roots, limit_per_root=options["limit_per_league"])
+        summary = pipeline.run(
+            roots,
+            limit_per_root=options["limit_per_league"],
+            progress=self.stdout.write,
+        )
 
         self._report(summary, dry_run=dry_run)
 
@@ -173,6 +186,7 @@ class Command(BaseCommand):
             persist_to=options["persist_to"],
             command=shlex.split(options["wrangler_cmd"]),
             cwd=options["wrangler_cwd"],
+            max_workers=options["local_workers"],
         )
 
     def _report(self, summary, *, dry_run: bool) -> None:

--- a/archive/packaging/__init__.py
+++ b/archive/packaging/__init__.py
@@ -9,7 +9,13 @@ from .keys import MANIFEST_NAME, derive_game_key, league_from_root
 from .packager import PackageResult, PackagingError, package_to_hls
 from .pipeline import PackagingPipeline, PackagingSummary
 from .probe import MediaProbe, ProbeError, probe_media
-from .uploader import InMemoryUploader, R2Uploader, SyncResult, Uploader
+from .uploader import (
+    InMemoryUploader,
+    R2Uploader,
+    SyncResult,
+    Uploader,
+    WranglerLocalUploader,
+)
 
 __all__ = [
     "MANIFEST_NAME",
@@ -23,6 +29,7 @@ __all__ = [
     "R2Uploader",
     "SyncResult",
     "Uploader",
+    "WranglerLocalUploader",
     "derive_game_key",
     "league_from_root",
     "package_to_hls",

--- a/archive/packaging/pipeline.py
+++ b/archive/packaging/pipeline.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import logging
 import tempfile
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -23,6 +23,10 @@ from .probe import probe_media
 from .uploader import Uploader
 
 logger = logging.getLogger("archive")
+
+# Optional progress callback. Pipelines that want per-file progress (e.g. the
+# management command writing to its stdout) pass one of these into ``run``.
+ProgressCallback = Callable[[str], None]
 
 # Container extensions worth probing. Mirrors the catalog scanner's set; the
 # archive is overwhelmingly .mp4 with a couple of .ts.
@@ -105,22 +109,35 @@ class PackagingPipeline:
                 yield path
 
     def run(
-        self, roots: list[Path], *, limit_per_root: int | None = None
+        self,
+        roots: list[Path],
+        *,
+        limit_per_root: int | None = None,
+        progress: ProgressCallback | None = None,
     ) -> PackagingSummary:
         summary = PackagingSummary()
         for root in roots:
             if not root.is_dir():
                 logger.warning("not a directory, skipping: %s", root)
                 continue
-            for processed_here, source in enumerate(self.iter_source_files(root)):
-                if limit_per_root is not None and processed_here >= limit_per_root:
-                    break
-                self._process_file(root, source, summary)
+            sources = list(self.iter_source_files(root))
+            if limit_per_root is not None:
+                sources = sources[:limit_per_root]
+            total = len(sources)
+            for index, source in enumerate(sources, start=1):
+                if progress is not None:
+                    progress(f"[{index}/{total}] packaging {source.name}")
+                self._process_file(root, source, summary, progress=progress)
         self._log_summary(summary)
         return summary
 
     def _process_file(
-        self, root: Path, source: Path, summary: PackagingSummary
+        self,
+        root: Path,
+        source: Path,
+        summary: PackagingSummary,
+        *,
+        progress: ProgressCallback | None = None,
     ) -> None:
         try:
             probe = probe_media(source)
@@ -133,11 +150,21 @@ class PackagingPipeline:
                     segment_duration=self._segment_duration,
                 )
                 if not self._dry_run:
+                    object_count = 1 + len(result.segment_paths)  # manifest + segs/init
+                    if progress is not None:
+                        progress(f"  loading {object_count} objects to {key_prefix}…")
                     sync = self._uploader.sync_dir(key_prefix, Path(tmp))
                     summary.bytes_uploaded += sync.bytes_uploaded
+                    if progress is not None:
+                        progress(
+                            f"  loaded {len(sync.uploaded_keys)} objects "
+                            f"({sync.bytes_uploaded} bytes)"
+                        )
         except Exception as exc:  # isolate one file's failure from the batch
             logger.exception("failed to package %s", source)
             summary.failures.append(FailedFile(path=source, error=str(exc)))
+            if progress is not None:
+                progress(f"  FAILED: {exc}")
             return
 
         summary.files_processed += 1

--- a/archive/packaging/uploader.py
+++ b/archive/packaging/uploader.py
@@ -13,12 +13,15 @@ delete — so the same logic drives the real Cloudflare R2 backend
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
+import time
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
+from typing import ClassVar
 
 logger = logging.getLogger("archive")
 
@@ -211,9 +214,26 @@ class WranglerLocalUploader(Uploader):
     process so wall-clock scales close to linearly with the worker count, and
     Miniflare's SQLite (in WAL mode) accepts concurrent writers. Set to ``1``
     for the sequential, debug-friendly behavior.
+
+    ``max_attempts`` adds retry-with-backoff around each put: the wrangler CLI
+    has many tiny ways to transiently fail (npm-registry update fetch hiccups,
+    SQLite ``BUSY`` under parallel writers, workerd 500s) and one failed put
+    is enough to abort a 400-object game. Retries make those self-healing.
     """
 
     _DEFAULT_MAX_WORKERS = 8
+    _DEFAULT_MAX_ATTEMPTS = 3
+    _DEFAULT_RETRY_BACKOFF_BASE = 1.0
+
+    # Env vars injected into every wrangler subprocess to suppress the CLI's
+    # background network calls. Even with ``--local`` the wrangler binary will
+    # fetch update-check / telemetry endpoints on each invocation by default;
+    # those fetches are a recurring source of transient ``fetch failed`` errors
+    # mid-batch. Disabling them removes the cause entirely.
+    _WRANGLER_ENV: ClassVar[dict[str, str]] = {
+        "WRANGLER_SEND_METRICS": "false",
+        "NO_UPDATE_NOTIFIER": "1",
+    }
 
     def __init__(
         self,
@@ -223,6 +243,8 @@ class WranglerLocalUploader(Uploader):
         command: Sequence[str] = ("npx", "wrangler"),
         cwd: Path | str | None = None,
         max_workers: int = _DEFAULT_MAX_WORKERS,
+        max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+        retry_backoff_base: float = _DEFAULT_RETRY_BACKOFF_BASE,
         runner: WranglerRunner | None = None,
     ) -> None:
         self.bucket = bucket
@@ -230,6 +252,8 @@ class WranglerLocalUploader(Uploader):
         self._command = list(command)
         self._cwd = Path(cwd) if cwd else None
         self._max_workers = max(1, max_workers)
+        self._max_attempts = max(1, max_attempts)
+        self._retry_backoff_base = max(0.0, retry_backoff_base)
         self._runner = runner or self._run_subprocess
 
     def _wrangler(self, *args: str) -> list[str]:
@@ -239,6 +263,7 @@ class WranglerLocalUploader(Uploader):
         return cmd
 
     def _run_subprocess(self, cmd: Sequence[str]) -> None:
+        env = {**os.environ, **self._WRANGLER_ENV}
         try:
             subprocess.run(
                 list(cmd),
@@ -246,6 +271,7 @@ class WranglerLocalUploader(Uploader):
                 text=True,
                 check=True,
                 cwd=str(self._cwd) if self._cwd else None,
+                env=env,
             )
         except FileNotFoundError as exc:  # pragma: no cover - environment-dependent
             raise RuntimeError(
@@ -255,6 +281,32 @@ class WranglerLocalUploader(Uploader):
         except subprocess.CalledProcessError as exc:  # pragma: no cover
             raise RuntimeError(f"wrangler failed: {exc.stderr}") from exc
 
+    def _invoke_with_retry(self, cmd: Sequence[str], *, label: str) -> None:
+        """Run ``cmd`` via the runner, retrying transient failures with backoff."""
+        last_exc: BaseException | None = None
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                self._runner(cmd)
+                if attempt > 1:
+                    logger.info("%s succeeded on attempt %d", label, attempt)
+                return
+            except RuntimeError as exc:
+                last_exc = exc
+                if attempt >= self._max_attempts:
+                    break
+                backoff = self._retry_backoff_base * (2 ** (attempt - 1))
+                logger.warning(
+                    "%s failed (attempt %d/%d), retrying in %.1fs: %s",
+                    label,
+                    attempt,
+                    self._max_attempts,
+                    backoff,
+                    exc,
+                )
+                time.sleep(backoff)
+        assert last_exc is not None
+        raise last_exc
+
     def list_keys(self, prefix: str) -> set[str]:
         raise NotImplementedError(
             "the wrangler CLI cannot list R2 objects "
@@ -262,21 +314,23 @@ class WranglerLocalUploader(Uploader):
         )
 
     def put_file(self, key: str, local_path: Path, content_type: str) -> int:
-        self._runner(
-            self._wrangler(
-                "put",
-                f"{self.bucket}/{key}",
-                "--file",
-                str(local_path),
-                "--content-type",
-                content_type,
-            )
+        cmd = self._wrangler(
+            "put",
+            f"{self.bucket}/{key}",
+            "--file",
+            str(local_path),
+            "--content-type",
+            content_type,
         )
+        self._invoke_with_retry(cmd, label=f"put {key}")
         return local_path.stat().st_size
 
     def delete_keys(self, keys: Iterable[str]) -> None:
         for key in keys:
-            self._runner(self._wrangler("delete", f"{self.bucket}/{key}"))
+            self._invoke_with_retry(
+                self._wrangler("delete", f"{self.bucket}/{key}"),
+                label=f"delete {key}",
+            )
 
     def sync_dir(self, prefix: str, local_dir: Path) -> SyncResult:
         """Upload every file under ``local_dir`` to ``prefix`` (upload-only).

--- a/archive/packaging/uploader.py
+++ b/archive/packaging/uploader.py
@@ -13,8 +13,9 @@ delete — so the same logic drives the real Cloudflare R2 backend
 from __future__ import annotations
 
 import logging
+import subprocess
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -178,3 +179,117 @@ class R2Uploader(Uploader):
         for start in range(0, len(batch), self._DELETE_BATCH):
             chunk = batch[start : start + self._DELETE_BATCH]
             self._client.delete_objects(Bucket=self.bucket, Delete={"Objects": chunk})
+
+
+WranglerRunner = Callable[[Sequence[str]], None]
+
+
+class WranglerLocalUploader(Uploader):
+    """Local Miniflare R2 backend for the cost-free PoC (ADR-0008 / TGF-362).
+
+    Loads packaged objects into the same local R2 store ``wrangler dev`` serves
+    by shelling out to ``wrangler r2 object put ... --local``. This is the
+    local-first path that lets the PoC run without provisioning real R2.
+
+    The wrangler CLI exposes only ``get``/``put``/``delete`` for objects — there
+    is no ``list`` (cloudflare/workers-sdk#13008) — so the base class's
+    list-then-delete orphan sweep cannot run here. :meth:`sync_dir` is therefore
+    **upload-only**: a ``put`` overwrites the object at a key, but re-packaging a
+    game into *fewer* segments than a prior run may leave stale ones behind. For
+    the static catalog that is rare and harmless for the PoC, and a prefix can be
+    cleared by hand via :meth:`delete_keys`. The remote :class:`R2Uploader` keeps
+    full idempotency for production (TGF-364).
+
+    ``persist_to`` must match the directory ``wrangler dev`` uses or the Worker
+    will not see the loaded objects (both default to ``.wrangler/state``).
+    ``cwd`` runs wrangler from the Worker project directory so its config and
+    persistence line up.
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket: str,
+        persist_to: Path | str | None = None,
+        command: Sequence[str] = ("npx", "wrangler"),
+        cwd: Path | str | None = None,
+        runner: WranglerRunner | None = None,
+    ) -> None:
+        self.bucket = bucket
+        self._persist_to = Path(persist_to) if persist_to else None
+        self._command = list(command)
+        self._cwd = Path(cwd) if cwd else None
+        self._runner = runner or self._run_subprocess
+
+    def _wrangler(self, *args: str) -> list[str]:
+        cmd = [*self._command, "r2", "object", *args, "--local"]
+        if self._persist_to is not None:
+            cmd += ["--persist-to", str(self._persist_to)]
+        return cmd
+
+    def _run_subprocess(self, cmd: Sequence[str]) -> None:
+        try:
+            subprocess.run(
+                list(cmd),
+                capture_output=True,
+                text=True,
+                check=True,
+                cwd=str(self._cwd) if self._cwd else None,
+            )
+        except FileNotFoundError as exc:  # pragma: no cover - environment-dependent
+            raise RuntimeError(
+                "wrangler executable not found; install it or pass --wrangler-cmd "
+                "/ --wrangler-cwd pointing at the Worker project"
+            ) from exc
+        except subprocess.CalledProcessError as exc:  # pragma: no cover
+            raise RuntimeError(f"wrangler failed: {exc.stderr}") from exc
+
+    def list_keys(self, prefix: str) -> set[str]:
+        raise NotImplementedError(
+            "the wrangler CLI cannot list R2 objects "
+            "(cloudflare/workers-sdk#13008); local sync is upload-only"
+        )
+
+    def put_file(self, key: str, local_path: Path, content_type: str) -> int:
+        self._runner(
+            self._wrangler(
+                "put",
+                f"{self.bucket}/{key}",
+                "--file",
+                str(local_path),
+                "--content-type",
+                content_type,
+            )
+        )
+        return local_path.stat().st_size
+
+    def delete_keys(self, keys: Iterable[str]) -> None:
+        for key in keys:
+            self._runner(self._wrangler("delete", f"{self.bucket}/{key}"))
+
+    def sync_dir(self, prefix: str, local_dir: Path) -> SyncResult:
+        """Upload every file under ``local_dir`` to ``prefix`` (upload-only).
+
+        Unlike the base implementation this neither lists nor deletes: the
+        wrangler CLI cannot enumerate objects, so orphan cleanup is skipped.
+        """
+        uploaded: list[str] = []
+        bytes_uploaded = 0
+        for path in _iter_files(local_dir):
+            relative = path.relative_to(local_dir).as_posix()
+            key = f"{prefix}/{relative}"
+            bytes_uploaded += self.put_file(key, path, content_type_for(path))
+            uploaded.append(key)
+
+        logger.debug(
+            "loaded %s into local R2: %d objects, %d bytes (upload-only, no sweep)",
+            prefix,
+            len(uploaded),
+            bytes_uploaded,
+        )
+        return SyncResult(
+            prefix=prefix,
+            uploaded_keys=uploaded,
+            deleted_keys=[],
+            bytes_uploaded=bytes_uploaded,
+        )

--- a/archive/packaging/uploader.py
+++ b/archive/packaging/uploader.py
@@ -16,6 +16,7 @@ import logging
 import subprocess
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -204,7 +205,15 @@ class WranglerLocalUploader(Uploader):
     will not see the loaded objects (both default to ``.wrangler/state``).
     ``cwd`` runs wrangler from the Worker project directory so its config and
     persistence line up.
+
+    ``max_workers`` parallelizes the per-object ``wrangler r2 object put``
+    invocations across a thread pool; each invocation spawns its own Node
+    process so wall-clock scales close to linearly with the worker count, and
+    Miniflare's SQLite (in WAL mode) accepts concurrent writers. Set to ``1``
+    for the sequential, debug-friendly behavior.
     """
+
+    _DEFAULT_MAX_WORKERS = 8
 
     def __init__(
         self,
@@ -213,12 +222,14 @@ class WranglerLocalUploader(Uploader):
         persist_to: Path | str | None = None,
         command: Sequence[str] = ("npx", "wrangler"),
         cwd: Path | str | None = None,
+        max_workers: int = _DEFAULT_MAX_WORKERS,
         runner: WranglerRunner | None = None,
     ) -> None:
         self.bucket = bucket
         self._persist_to = Path(persist_to) if persist_to else None
         self._command = list(command)
         self._cwd = Path(cwd) if cwd else None
+        self._max_workers = max(1, max_workers)
         self._runner = runner or self._run_subprocess
 
     def _wrangler(self, *args: str) -> list[str]:
@@ -270,22 +281,39 @@ class WranglerLocalUploader(Uploader):
     def sync_dir(self, prefix: str, local_dir: Path) -> SyncResult:
         """Upload every file under ``local_dir`` to ``prefix`` (upload-only).
 
-        Unlike the base implementation this neither lists nor deletes: the
-        wrangler CLI cannot enumerate objects, so orphan cleanup is skipped.
+        Unlike the base implementation this neither lists nor deletes — the
+        wrangler CLI cannot enumerate objects, so orphan cleanup is skipped —
+        and puts are issued in parallel across ``self._max_workers`` threads,
+        since per-call Node spin-up dominates the wall-clock cost.
         """
+        jobs = [
+            (f"{prefix}/{path.relative_to(local_dir).as_posix()}", path)
+            for path in _iter_files(local_dir)
+        ]
+
         uploaded: list[str] = []
         bytes_uploaded = 0
-        for path in _iter_files(local_dir):
-            relative = path.relative_to(local_dir).as_posix()
-            key = f"{prefix}/{relative}"
-            bytes_uploaded += self.put_file(key, path, content_type_for(path))
-            uploaded.append(key)
 
+        def _upload(job: tuple[str, Path]) -> tuple[str, int]:
+            key, path = job
+            return key, self.put_file(key, path, content_type_for(path))
+
+        # Cap workers at the job count so the pool isn't oversized for small games.
+        workers = min(self._max_workers, max(1, len(jobs)))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = [pool.submit(_upload, job) for job in jobs]
+            for future in as_completed(futures):
+                key, written = future.result()
+                uploaded.append(key)
+                bytes_uploaded += written
+
+        uploaded.sort()  # `as_completed` is non-deterministic; keep output stable.
         logger.debug(
-            "loaded %s into local R2: %d objects, %d bytes (upload-only, no sweep)",
+            "loaded %s into local R2: %d objects, %d bytes (upload-only, %d workers)",
             prefix,
             len(uploaded),
             bytes_uploaded,
+            workers,
         )
         return SyncResult(
             prefix=prefix,

--- a/tests/test_package_hls_command.py
+++ b/tests/test_package_hls_command.py
@@ -121,3 +121,18 @@ def test_builds_local_uploader_when_bucket_given(tmp_path, patched):
     call_command("package_hls", str(root), "--local", "--bucket", "film", stdout=out)
     assert "files processed : 0" in out.getvalue()
     assert "local R2 (Miniflare)" in out.getvalue()
+
+
+def test_dry_run_emits_per_file_progress(tmp_path, patched):
+    """Each source file gets a [i/N] packaging line so runs aren't silent."""
+    root = tmp_path / "NFL (1920)"
+    root.mkdir()
+    (root / "game-a.mp4").write_bytes(b"v" * 50)
+    (root / "game-b.mp4").write_bytes(b"v" * 50)
+
+    out = StringIO()
+    call_command("package_hls", str(root), "--dry-run", stdout=out)
+
+    text = out.getvalue()
+    assert "[1/2] packaging game-a.mp4" in text
+    assert "[2/2] packaging game-b.mp4" in text

--- a/tests/test_package_hls_command.py
+++ b/tests/test_package_hls_command.py
@@ -92,3 +92,32 @@ def test_rejects_non_positive_segment_duration(tmp_path, settings):
     root.mkdir()
     with pytest.raises(CommandError, match="segment-duration"):
         call_command("package_hls", str(root), "--dry-run", "--segment-duration", "0")
+
+
+def test_local_and_dry_run_are_mutually_exclusive(tmp_path):
+    root = tmp_path / "NFL (1920)"
+    root.mkdir()
+    with pytest.raises(CommandError, match="mutually exclusive"):
+        call_command(
+            "package_hls", str(root), "--dry-run", "--local", "--bucket", "film"
+        )
+
+
+def test_local_requires_a_bucket(tmp_path, settings):
+    root = tmp_path / "NFL (1920)"
+    root.mkdir()
+    settings.R2_BUCKET = None
+    with pytest.raises(CommandError, match="needs a bucket name"):
+        call_command("package_hls", str(root), "--local")
+
+
+def test_builds_local_uploader_when_bucket_given(tmp_path, patched):
+    # Empty root -> zero files -> no wrangler is ever invoked, but the local
+    # uploader is constructed, exercising the --local wiring without the CLI.
+    root = tmp_path / "NFL (1920)"
+    root.mkdir()
+
+    out = StringIO()
+    call_command("package_hls", str(root), "--local", "--bucket", "film", stdout=out)
+    assert "files processed : 0" in out.getvalue()
+    assert "local R2 (Miniflare)" in out.getvalue()

--- a/tests/test_packaging_uploader.py
+++ b/tests/test_packaging_uploader.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from archive.packaging.uploader import (
     InMemoryUploader,
+    WranglerLocalUploader,
     content_type_for,
 )
 
@@ -72,3 +75,91 @@ def test_sync_dir_does_not_touch_other_games(tmp_path):
     # "nfl/2024/" ancestry (prefix matching is boundary-aware).
     uploader.sync_dir("nfl/2024/game-a", _make_bundle(tmp_path / "a2"))
     assert any(k.startswith("nfl/2024/game-b/") for k in uploader.objects)
+
+
+class _RecordingRunner:
+    """Captures the wrangler argv lists instead of executing them."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd) -> None:
+        self.calls.append(list(cmd))
+
+
+def test_wrangler_local_put_builds_command(tmp_path):
+    manifest = tmp_path / "master.m3u8"
+    manifest.write_text("#EXTM3U\n")
+    runner = _RecordingRunner()
+    uploader = WranglerLocalUploader(
+        bucket="film", persist_to=".wrangler/state", runner=runner
+    )
+
+    written = uploader.put_file(
+        "nfl/2024/game/master.m3u8", manifest, "application/vnd.apple.mpegurl"
+    )
+
+    assert written == len("#EXTM3U\n")
+    assert runner.calls == [
+        [
+            "npx",
+            "wrangler",
+            "r2",
+            "object",
+            "put",
+            "film/nfl/2024/game/master.m3u8",
+            "--file",
+            str(manifest),
+            "--content-type",
+            "application/vnd.apple.mpegurl",
+            "--local",
+            "--persist-to",
+            ".wrangler/state",
+        ]
+    ]
+
+
+def test_wrangler_local_sync_is_upload_only(tmp_path):
+    bundle = _make_bundle(
+        tmp_path / "bundle", segments=("seg_00000.m4s", "seg_00001.m4s")
+    )
+    runner = _RecordingRunner()
+    uploader = WranglerLocalUploader(bucket="film", runner=runner)
+
+    result = uploader.sync_dir("nfl/2024/game", bundle)
+
+    # One `put` per file (init.mp4, master.m3u8, two segments); never lists/deletes.
+    assert len(runner.calls) == 4
+    assert all(call[4] == "put" for call in runner.calls)
+    assert result.deleted_keys == []
+    assert sorted(result.uploaded_keys) == [
+        "nfl/2024/game/init.mp4",
+        "nfl/2024/game/master.m3u8",
+        "nfl/2024/game/seg_00000.m4s",
+        "nfl/2024/game/seg_00001.m4s",
+    ]
+
+
+def test_wrangler_local_delete_keys_issues_commands():
+    runner = _RecordingRunner()
+    uploader = WranglerLocalUploader(bucket="film", runner=runner)
+
+    uploader.delete_keys(["nfl/2024/game/seg_00099.m4s"])
+
+    assert runner.calls == [
+        [
+            "npx",
+            "wrangler",
+            "r2",
+            "object",
+            "delete",
+            "film/nfl/2024/game/seg_00099.m4s",
+            "--local",
+        ]
+    ]
+
+
+def test_wrangler_local_list_is_unsupported():
+    uploader = WranglerLocalUploader(bucket="film", runner=_RecordingRunner())
+    with pytest.raises(NotImplementedError):
+        uploader.list_keys("nfl/2024/game")

--- a/tests/test_packaging_uploader.py
+++ b/tests/test_packaging_uploader.py
@@ -207,3 +207,65 @@ def test_wrangler_local_max_workers_one_runs_sequentially(tmp_path):
 
     assert len(runner.calls) == 3  # master + init + 1 segment
     assert sorted(result.uploaded_keys) == result.uploaded_keys
+
+
+class _FlakyRunner:
+    """Fake runner that raises on the first ``fail_first`` calls, then succeeds."""
+
+    def __init__(self, fail_first: int) -> None:
+        self.calls: list[list[str]] = []
+        self._fail_first = fail_first
+
+    def __call__(self, cmd) -> None:
+        self.calls.append(list(cmd))
+        if len(self.calls) <= self._fail_first:
+            raise RuntimeError(f"simulated transient failure {len(self.calls)}")
+
+
+def test_wrangler_local_put_retries_transient_failures(tmp_path):
+    payload = tmp_path / "a.bin"
+    payload.write_bytes(b"data")
+    runner = _FlakyRunner(fail_first=2)
+    uploader = WranglerLocalUploader(
+        bucket="film",
+        max_attempts=3,
+        retry_backoff_base=0,  # no sleep in tests
+        runner=runner,
+    )
+
+    written = uploader.put_file("test/a", payload, "application/octet-stream")
+
+    assert written == 4
+    assert len(runner.calls) == 3  # 2 failures + 1 success
+
+
+def test_wrangler_local_put_raises_after_exhausting_retries(tmp_path):
+    payload = tmp_path / "a.bin"
+    payload.write_bytes(b"data")
+    runner = _FlakyRunner(fail_first=5)  # always fails within the attempt budget
+    uploader = WranglerLocalUploader(
+        bucket="film",
+        max_attempts=3,
+        retry_backoff_base=0,
+        runner=runner,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated transient failure"):
+        uploader.put_file("test/a", payload, "application/octet-stream")
+    assert len(runner.calls) == 3
+
+
+def test_wrangler_local_max_attempts_one_disables_retries(tmp_path):
+    payload = tmp_path / "a.bin"
+    payload.write_bytes(b"data")
+    runner = _FlakyRunner(fail_first=1)
+    uploader = WranglerLocalUploader(
+        bucket="film",
+        max_attempts=1,
+        retry_backoff_base=0,
+        runner=runner,
+    )
+
+    with pytest.raises(RuntimeError):
+        uploader.put_file("test/a", payload, "application/octet-stream")
+    assert len(runner.calls) == 1  # no retry

--- a/tests/test_packaging_uploader.py
+++ b/tests/test_packaging_uploader.py
@@ -163,3 +163,47 @@ def test_wrangler_local_list_is_unsupported():
     uploader = WranglerLocalUploader(bucket="film", runner=_RecordingRunner())
     with pytest.raises(NotImplementedError):
         uploader.list_keys("nfl/2024/game")
+
+
+def test_wrangler_local_sync_parallelizes_puts(tmp_path):
+    """Sync issues puts concurrently up to max_workers and returns stable output."""
+    import threading
+
+    bundle = _make_bundle(
+        tmp_path / "bundle",
+        segments=tuple(f"seg_{i:05d}.m4s" for i in range(8)),
+    )
+
+    inflight = 0
+    peak_inflight = 0
+    lock = threading.Lock()
+
+    def slow_runner(_cmd):
+        nonlocal inflight, peak_inflight
+        with lock:
+            inflight += 1
+            peak_inflight = max(peak_inflight, inflight)
+        # Hold the call open long enough to overlap with siblings.
+        threading.Event().wait(0.05)
+        with lock:
+            inflight -= 1
+
+    uploader = WranglerLocalUploader(bucket="film", max_workers=4, runner=slow_runner)
+    result = uploader.sync_dir("nfl/2024/game", bundle)
+
+    # 10 files (manifest + init + 8 segments), every put issued, output stable.
+    assert len(result.uploaded_keys) == 10
+    assert result.uploaded_keys == sorted(result.uploaded_keys)
+    assert peak_inflight > 1, "expected concurrent puts with max_workers=4"
+    assert peak_inflight <= 4, "should not exceed configured max_workers"
+
+
+def test_wrangler_local_max_workers_one_runs_sequentially(tmp_path):
+    bundle = _make_bundle(tmp_path / "bundle", segments=("seg_00000.m4s",))
+    runner = _RecordingRunner()
+    uploader = WranglerLocalUploader(bucket="film", max_workers=1, runner=runner)
+
+    result = uploader.sync_dir("nfl/2024/game", bundle)
+
+    assert len(runner.calls) == 3  # master + init + 1 segment
+    assert sorted(result.uploaded_keys) == result.uploaded_keys


### PR DESCRIPTION
## Summary

Adds the **local-first** path for the v1 video-delivery PoC (Jira **TGF-362** / ADR-0008), so the pipeline can run end-to-end with **no Cloudflare spend**.

The packaging pipeline already existed and was wired for remote R2 (boto3). The missing piece was a backend that loads packaged HLS into the same local R2 store `wrangler dev` serves. This PR adds it:

- **`WranglerLocalUploader`** (`archive/packaging/uploader.py`) — a third `Uploader` backend alongside `R2Uploader`/`InMemoryUploader`. Shells out to `wrangler r2 object put … --local` (and `delete`), with an injectable runner so it's unit-testable without wrangler installed. Honors the runbook gotchas: bucket *name* (not binding), `--content-type` per object, and `--persist-to`/`cwd` so objects land where `wrangler dev` reads them.
- **`package_hls --local`** — new flags `--local`, `--bucket`, `--persist-to`, `--wrangler-cmd`, `--wrangler-cwd`. Mutually exclusive with `--dry-run`.

Usage:
```bash
uvrm package_hls "/mnt/g/NFL (1920)/NFL Full Games (1920)/Season 2024" \
    --local --bucket film --limit-per-league 1
# then, in the Worker project: wrangler dev  (serves what was just loaded)
```

This executes runbook steps 1–3 (remux → key layout → load into local R2); `wrangler dev` and browser verification remain the interactive steps.

## Tests

`tests/test_packaging_uploader.py` and `tests/test_package_hls_command.py` — argv construction, upload-only `sync_dir`, `delete_keys`, the `list_keys` NotImplementedError, plus command wiring (`--local`/`--dry-run` mutual exclusion, bucket requirement, uploader selection). All 17 pass; ruff clean.

## Notes / caveats

- **Upload-only locally (no orphan sweep).** The `wrangler` CLI has no object-*list* command ([workers-sdk#13008](https://github.com/cloudflare/workers-sdk/issues/13008)), so the base class's list-then-delete idempotency can't run for the local backend. `put` overwrites same keys; re-packaging a game into *fewer* segments could leave a stale one. Rare/harmless for the static catalog and PoC; the remote `R2Uploader` keeps full idempotency for production (TGF-364).
- **Relative manifest URIs** — playback-from-R2 depends on `master.m3u8` referencing segments relatively rather than with absolute temp-dir paths. That's a property of the existing `package_to_hls` (unchanged here); worth confirming during PoC verification.

Tracking: Jira **TGF-362** (no associated GAM GitHub issue, so no `Closes`).