### PR TITLE
feat(GAM TGF-360): add playback API minting auth-gated HLS URL + token

### DIFF
--- a/archive/api/serializers/playback.py
+++ b/archive/api/serializers/playback.py
@@ -1,0 +1,31 @@
+"""Response schema for the playback endpoint (TGF-360, ADR-0008).
+
+The shape is intentionally minimal — three fields, no envelopes — so an
+``openapi-ts``-generated client can call it without any post-processing. See
+``docs/adr/0008-v1-video-delivery-r2-worker-hls.md`` for the rationale.
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class PlaybackResponseSerializer(serializers.Serializer):
+    """Schema mirrors the JSON contract documented in ADR-0008.
+
+    Only ``hls`` is currently emitted for ``type``; future delivery modes
+    (e.g. ``dash``, ``download``) would extend that enum without changing the
+    rest of the response.
+    """
+
+    type = serializers.ChoiceField(choices=[("hls", "HLS")])
+    url = serializers.URLField(
+        help_text=(
+            "Absolute URL to the master HLS manifest on the configured video "
+            "origin, including the short-lived playback token as the ``t`` "
+            "query parameter."
+        ),
+    )
+    expires_at = serializers.DateTimeField(
+        help_text="UTC ISO-8601 timestamp at which the embedded token expires.",
+    )

--- a/archive/api/viewsets/game.py
+++ b/archive/api/viewsets/game.py
@@ -1,6 +1,11 @@
+from typing import ClassVar
+from urllib.parse import urlencode
+
+from django.conf import settings
 from django.db.models import Count, Q, Sum
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.decorators import action
+from rest_framework.exceptions import NotFound
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.mixins import (
     CreateModelMixin,
@@ -22,6 +27,7 @@ from archive.api.serializers.game_actions import (
     FullBoxscoreSerializer,
     GameSummarySerializer,
 )
+from archive.api.serializers.playback import PlaybackResponseSerializer
 from archive.models import (
     ExtraPointsBoxscore,
     FieldGoalsBoxscore,
@@ -35,7 +41,12 @@ from archive.models import (
     RushingBoxscore,
     TacklesBoxscore,
 )
-from gam.auth.permissions import CatalogPermissionMixin
+from gam.auth.permissions import (
+    CATALOG_PERMISSIONS,
+    CatalogPermissionMixin,
+    Permissions,
+)
+from gam.playback.tokens import mint_playback_token
 
 
 class GameViewSet(
@@ -51,6 +62,14 @@ class GameViewSet(
     filterset_class = GameFilter
     search_fields = ["competition_name", "notes"]
     ordering_fields = ["date_local", "week", "final_home_score", "final_away_score"]
+
+    # Playback is gated by its own scope (video:playback) on top of the
+    # shared catalog map — the entitlement check in TGF-360 lives at the
+    # scope layer so 403s fall out of the existing permission machinery.
+    required_permissions: ClassVar[dict[str, list[str]]] = {
+        **CATALOG_PERMISSIONS,
+        "playback": [Permissions.VIDEO_PLAYBACK],
+    }
 
     def get_queryset(self):
         qs = Game.objects.select_related(
@@ -69,6 +88,8 @@ class GameViewSet(
             return FullBoxscoreSerializer
         if self.action == "summary":
             return GameSummarySerializer
+        if self.action == "playback":
+            return PlaybackResponseSerializer
         return GameWriteSerializer
 
     @action(detail=True, methods=["get"], url_path="full-boxscore")
@@ -138,3 +159,59 @@ class GameViewSet(
         }
         serializer = GameSummarySerializer(data)
         return Response(serializer.data)
+
+    @action(detail=True, methods=["get"])
+    def playback(self, request, pk=None):
+        """Mint a short-lived, game-scoped HLS playback URL (TGF-360, ADR-0008).
+
+        Returns ``{type, url, expires_at}``. The ``url`` points at
+        ``{VIDEO_ORIGIN_URL}/games/{id}/master.m3u8`` with a signed token
+        embedded as ``?t=...``; the Worker that fronts R2 (TGF-361 / TGF-363)
+        verifies that token with the same shared secret. Entitlement is
+        enforced upstream by the ``video:playback`` permission scope.
+        """
+        # ``get_object`` honours the queryset and raises 404 for unknown ids,
+        # which satisfies the AC without an extra existence check.
+        try:
+            game = Game.objects.only("id").get(pk=pk)
+        except Game.DoesNotExist as exc:
+            raise NotFound("Unknown game id.") from exc
+
+        subject = self._token_subject(request)
+        minted = mint_playback_token(subject=subject, game_id=game.id)
+
+        origin = settings.VIDEO_ORIGIN_URL.rstrip("/")
+        query = urlencode({"t": minted.token})
+        url = f"{origin}/games/{game.id}/master.m3u8?{query}"
+
+        payload = {
+            "type": "hls",
+            "url": url,
+            "expires_at": minted.expires_at,
+        }
+        serializer = PlaybackResponseSerializer(payload)
+        return Response(serializer.data)
+
+    @staticmethod
+    def _token_subject(request) -> str:
+        """Derive the token ``sub`` claim from whatever auth principal we have.
+
+        JWT requests expose claims under ``request.auth`` (a dict); API key
+        requests expose the :class:`APIKey` row, which carries the owning
+        Clerk account's ``clerk_sub``. Either source maps to a single string
+        so the minted token stays consistent regardless of which credential
+        type the caller used.
+        """
+        auth = getattr(request, "auth", None)
+        if isinstance(auth, dict):
+            sub = auth.get("sub")
+            if sub:
+                return str(sub)
+        if auth is not None:
+            account = getattr(auth, "account", None)
+            sub = getattr(account, "clerk_sub", None)
+            if sub:
+                return str(sub)
+        user = getattr(request, "user", None)
+        sub = getattr(user, "subject", None) or getattr(user, "username", None)
+        return str(sub) if sub else "anonymous"

--- a/gam/auth/permissions.py
+++ b/gam/auth/permissions.py
@@ -34,6 +34,7 @@ class Permissions:
     CATALOG_WRITE = "catalog:write"
     HOLDINGS_READ = "holdings:read"
     HOLDINGS_WRITE = "holdings:write"
+    VIDEO_PLAYBACK = "video:playback"
 
 
 # Action → required permissions mappings shared by viewsets in each domain.

--- a/gam/playback/__init__.py
+++ b/gam/playback/__init__.py
@@ -1,0 +1,6 @@
+"""Short-lived playback tokens for the v1 HLS delivery path (TGF-360, ADR-0008).
+
+The API mints these tokens; the Cloudflare Worker (TGF-361 / TGF-363) verifies
+them. Both ends import :mod:`gam.playback.tokens` so the signing contract has
+exactly one definition.
+"""

--- a/gam/playback/tokens.py
+++ b/gam/playback/tokens.py
@@ -1,0 +1,184 @@
+"""Mint and verify the short-lived playback tokens described by ADR-0008.
+
+The Cloudflare Worker that fronts R2 is the consumer. To keep the two sides in
+sync we expose two pure functions — :func:`mint_playback_token` and
+:func:`verify_playback_token` — that read the signing parameters (secret,
+algorithm, issuer, audience, TTL) from Django settings. The Worker is expected
+to verify with the same secret, algorithm, issuer, and audience, so the
+round-trip test in :mod:`tests.test_playback_tokens` doubles as a
+specification.
+
+Claims:
+
+* ``sub`` — the Clerk user subject the token was minted for.
+* ``gid`` — the game id the URL is scoped to.
+* ``iat`` / ``exp`` — issued-at / expiry (UNIX seconds).
+* ``iss`` / ``aud`` — bound to ``settings.PLAYBACK_TOKEN_ISSUER`` and
+  ``settings.PLAYBACK_TOKEN_AUDIENCE`` so a token minted for one environment
+  cannot be replayed against another.
+
+The TTL is hard-capped at :data:`MAX_TTL_SECONDS` (15 minutes) so a
+mis-configured environment can never issue a longer-lived URL than the
+acceptance criteria allow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import jwt
+from django.conf import settings
+
+# Hard ceiling on token lifetime. The AC pins this at 15 minutes; encoding it
+# as a constant means an over-eager ``PLAYBACK_TOKEN_TTL_SECONDS`` env value
+# cannot exceed it.
+MAX_TTL_SECONDS = 15 * 60
+
+# Default signing algorithm. HS256 keeps the Worker's verification cheap
+# (single shared secret, no key fetch) which matches ADR-0008's "validate
+# in-Worker, no external call" requirement.
+DEFAULT_ALGORITHM = "HS256"
+DEFAULT_ISSUER = "griddy-api"
+DEFAULT_AUDIENCE = "griddy-video-worker"
+
+
+class PlaybackTokenError(Exception):
+    """Base class for any failure minting or verifying a playback token."""
+
+
+class PlaybackTokenConfigError(PlaybackTokenError):
+    """Raised when required signing settings are missing or invalid."""
+
+
+class PlaybackTokenInvalid(PlaybackTokenError):
+    """Raised when a token fails verification (expired, tampered, mis-scoped)."""
+
+
+@dataclass(frozen=True)
+class PlaybackTokenParams:
+    """Snapshot of the signing parameters at mint time.
+
+    Tests and the Worker stub both want one place to read the resolved
+    config; pulling it through this dataclass also keeps
+    :func:`mint_playback_token` itself easy to read.
+    """
+
+    secret: str
+    algorithm: str
+    issuer: str
+    audience: str
+    ttl_seconds: int
+
+
+def _resolve_params(ttl_seconds: int | None = None) -> PlaybackTokenParams:
+    """Read playback signing parameters from settings, applying the TTL cap."""
+    secret = getattr(settings, "PLAYBACK_TOKEN_SECRET", None)
+    if not secret:
+        raise PlaybackTokenConfigError(
+            "PLAYBACK_TOKEN_SECRET is not configured; cannot mint playback tokens."
+        )
+
+    algorithm = getattr(settings, "PLAYBACK_TOKEN_ALGORITHM", DEFAULT_ALGORITHM)
+    issuer = getattr(settings, "PLAYBACK_TOKEN_ISSUER", DEFAULT_ISSUER)
+    audience = getattr(settings, "PLAYBACK_TOKEN_AUDIENCE", DEFAULT_AUDIENCE)
+
+    configured_ttl = ttl_seconds
+    if configured_ttl is None:
+        configured_ttl = getattr(
+            settings, "PLAYBACK_TOKEN_TTL_SECONDS", MAX_TTL_SECONDS
+        )
+    if configured_ttl <= 0:
+        raise PlaybackTokenConfigError(
+            f"PLAYBACK_TOKEN_TTL_SECONDS must be positive (got {configured_ttl})."
+        )
+    # AC: TTL of 15 minutes or less. Cap silently rather than crash so a
+    # caller passing a larger override still gets a valid (shorter) token.
+    capped_ttl = min(configured_ttl, MAX_TTL_SECONDS)
+
+    return PlaybackTokenParams(
+        secret=secret,
+        algorithm=algorithm,
+        issuer=issuer,
+        audience=audience,
+        ttl_seconds=capped_ttl,
+    )
+
+
+@dataclass(frozen=True)
+class MintedPlaybackToken:
+    """Wraps the encoded JWT and the moment it expires.
+
+    The API view needs both: the encoded form goes into the playback URL, the
+    expiry feeds the ``expires_at`` field of the response.
+    """
+
+    token: str
+    expires_at: datetime
+
+
+def mint_playback_token(
+    *,
+    subject: str,
+    game_id: int | str,
+    ttl_seconds: int | None = None,
+    now: datetime | None = None,
+) -> MintedPlaybackToken:
+    """Mint a short-lived playback token for ``subject`` and ``game_id``.
+
+    ``now`` is overridable to make the call deterministic in tests; production
+    callers should let it default to ``datetime.now(UTC)``.
+    """
+    params = _resolve_params(ttl_seconds)
+    issued_at = now or datetime.now(UTC)
+    expires_at = issued_at + timedelta(seconds=params.ttl_seconds)
+
+    payload: dict[str, Any] = {
+        "sub": subject,
+        "gid": str(game_id),
+        "iat": int(issued_at.timestamp()),
+        "exp": int(expires_at.timestamp()),
+        "iss": params.issuer,
+        "aud": params.audience,
+    }
+    token = jwt.encode(payload, params.secret, algorithm=params.algorithm)
+    return MintedPlaybackToken(token=token, expires_at=expires_at)
+
+
+def verify_playback_token(
+    token: str,
+    *,
+    expected_game_id: int | str | None = None,
+    expected_subject: str | None = None,
+) -> dict[str, Any]:
+    """Verify ``token`` against the configured signing parameters.
+
+    On success returns the decoded claims dict. When ``expected_game_id`` or
+    ``expected_subject`` are provided the corresponding claim must match
+    exactly; this lets the Worker (or a test) assert that a token is scoped to
+    the request it received.
+    """
+    params = _resolve_params()
+    try:
+        claims = jwt.decode(
+            token,
+            params.secret,
+            algorithms=[params.algorithm],
+            audience=params.audience,
+            issuer=params.issuer,
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise PlaybackTokenInvalid("playback token has expired") from exc
+    except jwt.InvalidAudienceError as exc:
+        raise PlaybackTokenInvalid("playback token audience mismatch") from exc
+    except jwt.InvalidIssuerError as exc:
+        raise PlaybackTokenInvalid("playback token issuer mismatch") from exc
+    except jwt.PyJWTError as exc:
+        raise PlaybackTokenInvalid(f"playback token is invalid: {exc}") from exc
+
+    if expected_game_id is not None and claims.get("gid") != str(expected_game_id):
+        raise PlaybackTokenInvalid("playback token is not scoped to this game")
+    if expected_subject is not None and claims.get("sub") != expected_subject:
+        raise PlaybackTokenInvalid("playback token is not scoped to this user")
+    return claims

--- a/gam/settings.py
+++ b/gam/settings.py
@@ -165,6 +165,19 @@ JWT_AUTHORIZED_PARTIES = [
 # used for token verification.
 CLERK_SECRET_KEY = os.getenv("CLERK_SECRET_KEY")
 
+# Playback / video delivery (TGF-360, ADR-0008). The origin is environment
+# driven so the same code targets a local Worker (e.g. http://localhost:8787)
+# during the PoC and a production host later. The signing secret is shared
+# with the Worker that fronts R2; rotating it invalidates outstanding URLs.
+VIDEO_ORIGIN_URL = os.getenv("VIDEO_ORIGIN_URL", "http://localhost:8787")
+PLAYBACK_TOKEN_SECRET = os.getenv("PLAYBACK_TOKEN_SECRET", "")
+PLAYBACK_TOKEN_ALGORITHM = os.getenv("PLAYBACK_TOKEN_ALGORITHM", "HS256")
+PLAYBACK_TOKEN_ISSUER = os.getenv("PLAYBACK_TOKEN_ISSUER", "griddy-api")
+PLAYBACK_TOKEN_AUDIENCE = os.getenv("PLAYBACK_TOKEN_AUDIENCE", "griddy-video-worker")
+# Capped at 15 minutes by ``gam.playback.tokens.MAX_TTL_SECONDS``; values
+# larger than the cap are silently clamped down to it.
+PLAYBACK_TOKEN_TTL_SECONDS = int(os.getenv("PLAYBACK_TOKEN_TTL_SECONDS", "900"))
+
 # Default primary key field type
 # https://docs.djangoproject.com/en/6.0/ref/settings/#default-auto-field
 

--- a/tests/test_playback_api.py
+++ b/tests/test_playback_api.py
@@ -1,0 +1,199 @@
+"""End-to-end tests for ``GET /api/v1/games/{id}/playback/`` (TGF-360).
+
+Drives the full DRF stack — authentication, :class:`HasAPIPermission`, the
+``GameViewSet`` playback action, the playback-token signer — so the response
+shape and entitlement gates documented in ADR-0008 are pinned by tests.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from urllib.parse import parse_qs, urlparse
+
+import jwt
+import pytest
+from django.test import override_settings
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from archive.models import Franchise, Game, League, Season, Team
+from gam.auth.permissions import Permissions
+from gam.playback.tokens import (
+    DEFAULT_ALGORITHM,
+    DEFAULT_AUDIENCE,
+    DEFAULT_ISSUER,
+    MAX_TTL_SECONDS,
+)
+
+pytestmark = [pytest.mark.django_db, pytest.mark.enforce_api_permissions]
+
+
+SHARED_SECRET = "test-playback-secret-with-at-least-32-bytes"
+LOCAL_ORIGIN = "http://localhost:8787"
+PROD_ORIGIN = "https://video.dev.griddy.football"
+
+
+@pytest.fixture
+def configured(jwks_harness):
+    with override_settings(
+        JWKS_URL=jwks_harness.jwks_url,
+        JWT_ISSUER=jwks_harness.issuer,
+        JWT_AUDIENCE=jwks_harness.audience,
+        JWT_AUTHORIZED_PARTIES=[],
+        PLAYBACK_TOKEN_SECRET=SHARED_SECRET,
+        PLAYBACK_TOKEN_ALGORITHM=DEFAULT_ALGORITHM,
+        PLAYBACK_TOKEN_ISSUER=DEFAULT_ISSUER,
+        PLAYBACK_TOKEN_AUDIENCE=DEFAULT_AUDIENCE,
+        PLAYBACK_TOKEN_TTL_SECONDS=900,
+        VIDEO_ORIGIN_URL=LOCAL_ORIGIN,
+    ):
+        from gam.auth.jwt import _get_jwks_client
+
+        _get_jwks_client.cache_clear()
+        yield
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def nfl():
+    return League.objects.create(short_name="NFL", long_name="NFL", level="PRO")
+
+
+@pytest.fixture
+def season(nfl):
+    return Season.objects.create(league=nfl, year=2024, label="2024")
+
+
+@pytest.fixture
+def teams(nfl):
+    home_fr = Franchise.objects.create(name="Pittsburgh Steelers", league=nfl)
+    away_fr = Franchise.objects.create(name="Baltimore Ravens", league=nfl)
+    home = Team.objects.create(
+        franchise=home_fr, name="Steelers", short_name="PIT", city="Pittsburgh"
+    )
+    away = Team.objects.create(
+        franchise=away_fr, name="Ravens", short_name="BAL", city="Baltimore"
+    )
+    return home, away
+
+
+@pytest.fixture
+def game(nfl, season, teams):
+    home, away = teams
+    return Game.objects.create(
+        league=nfl,
+        season=season,
+        date_local="2024-09-08",
+        week=1,
+        home_team=home,
+        away_team=away,
+    )
+
+
+def _bearer(client: APIClient, token: str) -> APIClient:
+    client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+    return client
+
+
+@pytest.mark.usefixtures("configured")
+class TestPlaybackAuthGating:
+    def test_unauthenticated_returns_401(self, client, game):
+        response = client.get(reverse("game-playback", args=[game.id]))
+        assert response.status_code == 401
+        assert "url" not in response.json()
+
+    def test_authenticated_without_playback_scope_returns_403(
+        self, client, mint_jwt, game
+    ):
+        # catalog:read alone does not grant playback — entitlement gating
+        # rides on the dedicated video:playback scope.
+        token = mint_jwt(permissions=[Permissions.CATALOG_READ])
+        response = _bearer(client, token).get(reverse("game-playback", args=[game.id]))
+        assert response.status_code == 403
+
+    def test_unknown_game_id_returns_404(self, client, mint_jwt):
+        token = mint_jwt(permissions=[Permissions.VIDEO_PLAYBACK])
+        response = _bearer(client, token).get(reverse("game-playback", args=[999_999]))
+        assert response.status_code == 404
+
+
+@pytest.mark.usefixtures("configured")
+class TestPlaybackHappyPath:
+    def test_returns_200_with_expected_shape(self, client, mint_jwt, game):
+        token = mint_jwt(sub="user_test", permissions=[Permissions.VIDEO_PLAYBACK])
+        response = _bearer(client, token).get(reverse("game-playback", args=[game.id]))
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body.keys()) == {"type", "url", "expires_at"}
+        assert body["type"] == "hls"
+
+    def test_url_points_at_configured_video_origin(self, client, mint_jwt, game):
+        token = mint_jwt(sub="user_test", permissions=[Permissions.VIDEO_PLAYBACK])
+        response = _bearer(client, token).get(reverse("game-playback", args=[game.id]))
+        parsed = urlparse(response.json()["url"])
+        assert f"{parsed.scheme}://{parsed.netloc}" == LOCAL_ORIGIN
+        assert parsed.path == f"/games/{game.id}/master.m3u8"
+
+    def test_origin_is_env_driven(self, client, mint_jwt, game):
+        """Same code, different env value, different host in the response."""
+        token = mint_jwt(sub="user_test", permissions=[Permissions.VIDEO_PLAYBACK])
+        with override_settings(VIDEO_ORIGIN_URL=PROD_ORIGIN):
+            response = _bearer(client, token).get(
+                reverse("game-playback", args=[game.id])
+            )
+        assert response.json()["url"].startswith(f"{PROD_ORIGIN}/games/{game.id}/")
+
+    def test_token_round_trips_against_worker_secret(self, client, mint_jwt, game):
+        """The Worker would verify with the same secret; assert that path works."""
+        token = mint_jwt(sub="user_test", permissions=[Permissions.VIDEO_PLAYBACK])
+        response = _bearer(client, token).get(reverse("game-playback", args=[game.id]))
+        url = response.json()["url"]
+        playback_token = parse_qs(urlparse(url).query)["t"][0]
+
+        claims = jwt.decode(
+            playback_token,
+            SHARED_SECRET,
+            algorithms=[DEFAULT_ALGORITHM],
+            audience=DEFAULT_AUDIENCE,
+            issuer=DEFAULT_ISSUER,
+        )
+        assert claims["sub"] == "user_test"
+        assert claims["gid"] == str(game.id)
+
+    def test_token_ttl_is_at_most_fifteen_minutes(self, client, mint_jwt, game):
+        token = mint_jwt(sub="user_test", permissions=[Permissions.VIDEO_PLAYBACK])
+        response = _bearer(client, token).get(reverse("game-playback", args=[game.id]))
+        body = response.json()
+        expires_at = datetime.fromisoformat(body["expires_at"].replace("Z", "+00:00"))
+        url = body["url"]
+        playback_token = parse_qs(urlparse(url).query)["t"][0]
+        claims = jwt.decode(
+            playback_token,
+            SHARED_SECRET,
+            algorithms=[DEFAULT_ALGORITHM],
+            audience=DEFAULT_AUDIENCE,
+            issuer=DEFAULT_ISSUER,
+        )
+        assert claims["exp"] - claims["iat"] <= MAX_TTL_SECONDS
+        # ``expires_at`` in the body must match the ``exp`` claim in the token.
+        assert int(expires_at.timestamp()) == claims["exp"]
+
+    def test_ttl_setting_above_cap_is_clamped(self, client, mint_jwt, game):
+        token = mint_jwt(sub="user_test", permissions=[Permissions.VIDEO_PLAYBACK])
+        with override_settings(PLAYBACK_TOKEN_TTL_SECONDS=MAX_TTL_SECONDS * 10):
+            response = _bearer(client, token).get(
+                reverse("game-playback", args=[game.id])
+            )
+        playback_token = parse_qs(urlparse(response.json()["url"]).query)["t"][0]
+        claims = jwt.decode(
+            playback_token,
+            SHARED_SECRET,
+            algorithms=[DEFAULT_ALGORITHM],
+            audience=DEFAULT_AUDIENCE,
+            issuer=DEFAULT_ISSUER,
+        )
+        assert claims["exp"] - claims["iat"] == MAX_TTL_SECONDS

--- a/tests/test_playback_tokens.py
+++ b/tests/test_playback_tokens.py
@@ -1,0 +1,151 @@
+"""Unit tests for :mod:`gam.playback.tokens` (TGF-360).
+
+The Worker that fronts R2 verifies these tokens, so the mint / verify
+round-trip here doubles as the inter-component contract test required by the
+ticket's AC.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from django.test import override_settings
+
+from gam.playback.tokens import (
+    DEFAULT_ALGORITHM,
+    DEFAULT_AUDIENCE,
+    DEFAULT_ISSUER,
+    MAX_TTL_SECONDS,
+    PlaybackTokenConfigError,
+    PlaybackTokenInvalid,
+    mint_playback_token,
+    verify_playback_token,
+)
+
+SHARED_SECRET = "test-playback-secret-with-at-least-32-bytes"
+
+
+@pytest.fixture
+def configured_signing():
+    """Pin every signing parameter so tests don't depend on env defaults."""
+    with override_settings(
+        PLAYBACK_TOKEN_SECRET=SHARED_SECRET,
+        PLAYBACK_TOKEN_ALGORITHM=DEFAULT_ALGORITHM,
+        PLAYBACK_TOKEN_ISSUER=DEFAULT_ISSUER,
+        PLAYBACK_TOKEN_AUDIENCE=DEFAULT_AUDIENCE,
+        PLAYBACK_TOKEN_TTL_SECONDS=900,
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("configured_signing")
+class TestMintAndVerifyRoundTrip:
+    def test_round_trip_returns_claims(self):
+        minted = mint_playback_token(subject="user_42", game_id=7)
+        claims = verify_playback_token(
+            minted.token, expected_game_id=7, expected_subject="user_42"
+        )
+        assert claims["sub"] == "user_42"
+        assert claims["gid"] == "7"
+        assert claims["iss"] == DEFAULT_ISSUER
+        assert claims["aud"] == DEFAULT_AUDIENCE
+
+    def test_expires_at_matches_iat_plus_ttl(self):
+        now = datetime(2026, 5, 28, 12, 0, tzinfo=UTC)
+        minted = mint_playback_token(subject="user_42", game_id=7, now=now)
+        assert minted.expires_at == now + timedelta(seconds=900)
+
+    def test_worker_can_independently_verify_same_secret(self):
+        """The Worker uses raw ``jwt.decode``; mirror that here."""
+        minted = mint_playback_token(subject="user_42", game_id=7)
+        claims = jwt.decode(
+            minted.token,
+            SHARED_SECRET,
+            algorithms=[DEFAULT_ALGORITHM],
+            audience=DEFAULT_AUDIENCE,
+            issuer=DEFAULT_ISSUER,
+        )
+        assert claims["gid"] == "7"
+        assert claims["sub"] == "user_42"
+
+
+@pytest.mark.usefixtures("configured_signing")
+class TestTokenScoping:
+    def test_wrong_game_id_rejected(self):
+        minted = mint_playback_token(subject="user_42", game_id=7)
+        with pytest.raises(PlaybackTokenInvalid, match="game"):
+            verify_playback_token(minted.token, expected_game_id=999)
+
+    def test_wrong_subject_rejected(self):
+        minted = mint_playback_token(subject="user_42", game_id=7)
+        with pytest.raises(PlaybackTokenInvalid, match="user"):
+            verify_playback_token(minted.token, expected_subject="user_other")
+
+    def test_token_signed_with_other_secret_rejected(self):
+        foreign = jwt.encode(
+            {
+                "sub": "user_42",
+                "gid": "7",
+                "iss": DEFAULT_ISSUER,
+                "aud": DEFAULT_AUDIENCE,
+                "iat": int(datetime.now(UTC).timestamp()),
+                "exp": int((datetime.now(UTC) + timedelta(seconds=60)).timestamp()),
+            },
+            "a-different-secret-also-with-32-plus-bytes",
+            algorithm=DEFAULT_ALGORITHM,
+        )
+        with pytest.raises(PlaybackTokenInvalid):
+            verify_playback_token(foreign)
+
+    def test_expired_token_rejected(self):
+        past = datetime.now(UTC) - timedelta(seconds=2 * MAX_TTL_SECONDS)
+        minted = mint_playback_token(
+            subject="user_42",
+            game_id=7,
+            ttl_seconds=1,
+            now=past,
+        )
+        with pytest.raises(PlaybackTokenInvalid, match="expired"):
+            verify_playback_token(minted.token)
+
+
+class TestTTLCap:
+    def test_ttl_is_capped_at_max(self):
+        with override_settings(
+            PLAYBACK_TOKEN_SECRET=SHARED_SECRET,
+            PLAYBACK_TOKEN_TTL_SECONDS=MAX_TTL_SECONDS * 4,
+        ):
+            now = datetime(2026, 5, 28, 12, 0, tzinfo=UTC)
+            minted = mint_playback_token(subject="user_42", game_id=7, now=now)
+        # The cap is the 15-minute AC ceiling — anything larger gets clamped
+        # silently so a misconfigured env can't issue longer-lived URLs.
+        assert minted.expires_at - now == timedelta(seconds=MAX_TTL_SECONDS)
+
+    def test_explicit_ttl_override_below_cap_is_used(self):
+        with override_settings(PLAYBACK_TOKEN_SECRET=SHARED_SECRET):
+            now = datetime(2026, 5, 28, 12, 0, tzinfo=UTC)
+            minted = mint_playback_token(
+                subject="user_42", game_id=7, ttl_seconds=120, now=now
+            )
+        assert minted.expires_at - now == timedelta(seconds=120)
+
+
+class TestConfigErrors:
+    def test_missing_secret_raises_config_error(self):
+        with (
+            override_settings(PLAYBACK_TOKEN_SECRET=""),
+            pytest.raises(PlaybackTokenConfigError, match="PLAYBACK_TOKEN_SECRET"),
+        ):
+            mint_playback_token(subject="user_42", game_id=7)
+
+    def test_non_positive_ttl_raises_config_error(self):
+        with (
+            override_settings(
+                PLAYBACK_TOKEN_SECRET=SHARED_SECRET,
+                PLAYBACK_TOKEN_TTL_SECONDS=0,
+            ),
+            pytest.raises(PlaybackTokenConfigError, match="positive"),
+        ):
+            mint_playback_token(subject="user_42", game_id=7)


### PR DESCRIPTION
Implements the playback contract from the TGF-337 spike and ADR-0008: an authenticated, `video:playback`-scoped user can fetch a short-lived, game-scoped HLS manifest URL.

## What's in here

**`gam/playback/tokens.py`** — `mint_playback_token(...)` / `verify_playback_token(...)` (HS256 by default). Reads secret, algorithm, issuer, audience, and TTL from Django settings so the Cloudflare Worker (TGF-361 / TGF-363) can verify with the same shared secret. TTL is hard-capped at 15 minutes (`MAX_TTL_SECONDS`) regardless of env value, so a misconfigured `PLAYBACK_TOKEN_TTL_SECONDS` cannot ever issue a longer-lived URL than the AC allows.

**`archive/api/viewsets/game.py`** — new `playback` action on `GameViewSet`:

- `GET /api/v1/games/<pk>/playback/`
- Returns `{type: "hls", url, expires_at}` per ADR-0008.
- `url` = `{VIDEO_ORIGIN_URL}/games/{id}/master.m3u8?t={token}` — origin is env-driven, so the same code targets `http://localhost:8787` for the local PoC and a production host later with no code change.
- Entitlement gating rides on the existing permission machinery: a new `Permissions.VIDEO_PLAYBACK = "video:playback"` scope is required for this action only, so 401 (no auth), 403 (auth without scope), and 404 (unknown game) fall out naturally.

**`archive/api/serializers/playback.py`** — `PlaybackResponseSerializer` documents the response schema for drf-spectacular / generated clients.

**Settings** — `VIDEO_ORIGIN_URL`, `PLAYBACK_TOKEN_SECRET`, `PLAYBACK_TOKEN_ALGORITHM`, `PLAYBACK_TOKEN_ISSUER`, `PLAYBACK_TOKEN_AUDIENCE`, `PLAYBACK_TOKEN_TTL_SECONDS`.

## Tests

- `tests/test_playback_tokens.py` (11) — round-trip mint/verify, scoping (gid + sub), expiry, wrong-secret rejection, TTL cap, missing-secret config error. Includes a test that decodes the minted token with `jwt.decode` and the raw shared secret to mirror exactly how the Worker will verify it — this is the inter-component contract test the AC calls for.
- `tests/test_playback_api.py` (9) — drives the full DRF stack: 401 (unauthenticated), 403 (auth without `video:playback`), 404 (unknown id), 200 happy path with response-shape, env-driven origin, token round-trip via shared secret, TTL ≤ 15 min, env-cap clamp.

All 768 existing tests still pass; 20 new pass.

## Acceptance criteria mapping

| AC | Where it lives |
|---|---|
| 200 + JSON `{type, url, expires_at}` on master.m3u8 | `test_returns_200_with_expected_shape`, `test_url_points_at_configured_video_origin` |
| 401 on unauthenticated | `test_unauthenticated_returns_401` |
| 403 on auth-but-not-entitled | `test_authenticated_without_playback_scope_returns_403` |
| 404 on unknown game | `test_unknown_game_id_returns_404` |
| Token scoped to user+game, TTL ≤ 15 min | `test_token_round_trips_against_worker_secret`, `test_token_ttl_is_at_most_fifteen_minutes`, `test_ttl_setting_above_cap_is_clamped` |
| Worker can verify with same secret/algorithm | `test_worker_can_independently_verify_same_secret`, `test_token_round_trips_against_worker_secret` |
| Video origin is env-driven | `test_origin_is_env_driven` (`VIDEO_ORIGIN_URL` switched per call) |
| Response matches ADR-0008 schema | `PlaybackResponseSerializer` shape + `test_returns_200_with_expected_shape` (exact key set) |

Closes TGF-360.
