### PR TITLE
docs(TGF-338): add v1.5 video-at-scale spike deliverables (comparison, migration, backend design)

### DIFF
--- a/docs/video-scale/backend-design.md
+++ b/docs/video-scale/backend-design.md
@@ -1,0 +1,232 @@
+# v1.5 video backend — design sketch (TGF-338)
+
+_Spike deliverable 3 of 4. Companion to [comparison.md](./comparison.md),
+[migration-plan.md](./migration-plan.md), and
+[ADR-0009](https://github.com/Thistle-Grow-Software/griddy-web-portal/blob/main/docs/adr/0009-v15-video-delivery-scale.md)._
+
+A design sketch — not an implementation spec — for the v1.5 backend: the
+transcoding/ingestion pipeline, the R2 storage layout, signed-URL/token
+issuance at scale, and the clip-manifest service that unblocks TGF-339. It
+answers ticket questions #3, #6, and #7 and feeds the follow-up stories.
+
+Everything here **extends** the v1 pieces (Django playback API TGF-360, Worker
+gateway TGF-361, batch packager TGF-362) rather than replacing them.
+
+## 1. Ingestion / transcoding pipeline (#3)
+
+### Shape: one-time batch, not a persistent service
+
+The catalog is **static history** (TGF-337). So packaging is a **batch backfill**
+that runs once per source asset and then never again — not a standing pipeline.
+A persistent, autoscaling transcode service is only warranted once
+user-generated uploads land (out of scope for v1.5; see ADR-0009). The same code
+path is reused for the occasional new archival acquisition, invoked manually.
+
+```
+VideoAsset (GAM holdings)                      R2: griddy-video bucket
+      │  source MP4 on /mnt or S3                       │
+      ▼                                                 │
+ [ probe ]  ffprobe → codecs, bitrate, resolution       │
+      │                                                 │
+      ├─ conforming (99%, H.264/AAC) ─┐                 │
+      │                               ▼                 │
+      │                        [ ABR transcode ]        │
+      │                  ffmpeg → 240/480/720/1080       │
+      │                  (cap rungs at source res)       │
+      │                               │                 │
+      └─ non-conforming (~10 files) ──┤                 │
+            VP9/AV1/HEVC/Opus/AC-3    │                 │
+            transcode to H.264/AAC    │                 │
+                                      ▼                 │
+                              [ package: CMAF/fMP4 ]     │
+                          Shaka Packager / Bento4 mp4hls │
+                          → master.m3u8 + per-rung        │
+                            media playlists + init/seg    │
+                                      │                  ▼
+                                      └──── upload ──► games/{id}/...
+                                            (idempotent put,
+                                             content-type set)
+                                      │
+                                      ▼
+                          write PackagedRendition rows (GAM)
+                          status, ladder, checksum, segment count
+```
+
+### Bitrate ladder
+
+A standard 4-rung ladder, each rung **capped at the source resolution** (43.9%
+of the catalog is 720p, 39.7% is 480p — most files do not warrant a 1080p rung):
+
+| Rung | Resolution | ~Bitrate | Produced when source ≥ |
+| --- | --- | --- | --- |
+| 1080p | 1920×1080 | ~5 Mbps | 1080p |
+| 720p | 1280×720 | ~2.8 Mbps | 720p |
+| 480p | 854×480 | ~1.4 Mbps | 480p |
+| 240p | 426×240 | ~0.4 Mbps | always |
+
+Segment duration stays at the v1 **~6 s** target so existing segments and the
+gate behavior are unchanged. CMAF/fMP4 with a shared `init.mp4` per rung.
+
+### Where it runs
+
+One-time batch → cheapest correct answer is **own compute** (a workstation, a
+spot VM, or Fargate spot), writing straight to R2. Projected one-time cost
+~$300–500 (see comparison.md). No standing infrastructure. A new Django
+management command — `package_game --ladder abr` — generalizes the v1
+`poc_load_game`/TGF-362 packager from single-rendition `-c copy` to the ladder
+above, reusing its R2 uploader and measurement output.
+
+### Idempotency & provenance
+
+- Uploads are keyed by deterministic object path (below), so re-running is safe.
+- Each packaged ladder records a `PackagedRendition` row in GAM linked to the
+  `VideoAsset` (status, rung set, per-object SHA-256, segment count, ffmpeg
+  version) so a packaging run is auditable and re-derivable.
+
+## 2. Storage layout (R2)
+
+One bucket (`griddy-video`, as in v1). ABR adds a rung dimension under each
+game; the master manifest and the v1 single-rendition path stay valid so v1
+playback URLs never break during migration (see migration-plan.md).
+
+```
+games/{game_id}/
+  master.m3u8              # multivariant: lists all rungs (NEW: was single-rung in v1)
+  audio/
+    init.mp4
+    seg_00000.m4s …
+  v1080/
+    init.mp4
+    seg_00000.m4s …
+  v720/  v480/  v240/      # same shape per rung
+  master.v1.m3u8           # retained: the v1 single-rendition manifest (migration safety)
+```
+
+- Storage estimate: ~2–2.5× source for the ladder + retained originals → ~6–7.5
+  TB → ~$100–115/mo on R2, egress $0 (comparison.md).
+- Originals are **retained** (cold) so any rung can be re-derived without
+  re-acquiring the source.
+
+## 3. Access control & signed-URL issuance at scale (#7)
+
+v1 mints a **per-game** token (Django) that the Worker swaps for a **per-game,
+path-scoped signed cookie**. That is correct for single-game playback and is
+kept. v1.5 adds a second pattern for the cross-catalog clip experience, where a
+session touches many games and minting one cookie per game is too chatty.
+
+### Two token scopes
+
+| Scope | Use | Claim shape | Cookie path |
+| --- | --- | --- | --- |
+| **Game** (v1, kept) | Watch one full game | `{sub, gid, iss, aud, exp}` | `/games/{gid}/` |
+| **Session** (v1.5, new) | Browse/clip across the catalog | `{sub, ent, iss, aud, exp}` where `ent` = entitlement (e.g. allowed leagues / subscription tier) | `/` (entitlement checked per request) |
+
+The Worker's `authorize()` already validates HS256 claims and supports a missing
+`gid` (it falls back to `scopedTo() === true`). The v1.5 change is additive:
+when a credential carries `ent` instead of `gid`, the Worker checks the
+requested game against the entitlement claim rather than a single `gid` match.
+Entitlement stays **single-sourced in Django** (against Clerk identity, per
+ADR-0006) — the Worker still only verifies a token Django minted; it gains an
+entitlement check, not an identity surface.
+
+```
+Portal ──Clerk JWT──► Django  GET /api/playback/session
+                        │  check subscription/entitlement (Clerk → coach/team)
+                        ▼
+                 mint session token {sub, ent=[NFL,UFL], exp=+1h}
+Portal ◄──────────────── token ──────────────┘
+   │  player loads any games/{id}/master.m3u8?t=<session token>
+   ▼
+Worker  verify token → entitlement allows {id}? → set session cookie (Path=/) → stream
+```
+
+- **Lifetimes.** Game token: minutes (one-shot, swapped immediately for the
+  cookie). Session cookie: a few hours (must outlive a multi-game clip session),
+  silently re-minted by the portal on expiry — same rationale as the v1 ADR's
+  "credential must outlive a segment fetch".
+- **Per-coach subscription gating** lives entirely in the `ent` claim: Django
+  computes it from the authenticated user's subscription; the Worker enforces it
+  per request. Revoking access = not minting the next token (≤ cookie TTL to
+  take effect).
+- **CORS** is unchanged from v1 (explicit credentialed origins, `GET, HEAD`,
+  `Range`, range headers exposed).
+
+## 4. Clip-manifest service (#6, unblocks TGF-339)
+
+The headline v1.5 feature plays **arbitrary time ranges across the catalog**.
+Three options were on the table; the design picks the third.
+
+| Option | Storage | Compute | UX | Verdict |
+| --- | --- | --- | --- | --- |
+| Server-side concat → new HLS asset | New per clip (blows up) | Re-mux per clip | Seamless | Rejected — cost |
+| Client-side chained playback + seek jumps | None | None | Visible seams | Rejected — UX |
+| **Synthesized clip manifest over stored segments** | **None** | Generate a playlist (cheap) | Seamless within a rung; ~6 s edge granularity | **Chosen** |
+
+### How it works
+
+A clip is identified by `(game_id, start, end)`. The service emits an **HLS
+media playlist** that references the **already-stored ABR segments** overlapping
+`[start, end]`:
+
+```
+#EXTM3U
+#EXT-X-VERSION:7
+#EXT-X-MAP:URI="/games/2025001/v720/init.mp4"
+#EXT-X-START:TIME-OFFSET=0
+#EXTINF:6.0,
+/games/2025001/v720/seg_00042.m4s     # first segment covering `start`
+…                                      # whole segments in range
+#EXTINF:6.0,
+/games/2025001/v720/seg_00058.m4s     # last segment covering `end`
+#EXT-X-ENDLIST
+```
+
+- **No new storage, no re-encode** — the clip reuses the same segment objects the
+  full-game stream serves; only a small text manifest is generated.
+- **Granularity:** v1.5 ships at segment (~6 s) edges, with `EXT-X-START` for the
+  in-point. Frame-accurate trimming of the two boundary segments (a tiny
+  on-the-fly remux of ≤2 segments) is a documented later refinement, not a v1.5
+  blocker.
+- **Where it runs:** the manifest is generated where the segment timing is
+  known. Two viable homes — (a) **Django** `GET /api/games/{id}/clip.m3u8?start=&end=`
+  using packaging metadata, or (b) the **Worker**, computing segment indices from
+  the media playlist it already serves. Recommendation: **Django generates,
+  Worker gates** — it keeps timing logic next to the `PackagedRendition`
+  metadata and leaves the Worker a pure auth+stream gate. The clip manifest is
+  fetched under the same session token/cookie as any other object.
+- **Cross-catalog playlists** (a filtered set of clips from many games, the
+  NFL-Pro-style feature) become a **client-side ordered list of per-clip
+  manifests**, each gated by the one session token — the player loads them in
+  sequence. Seams fall on clip boundaries (expected for a highlight reel), not
+  mid-play.
+- **ABR is free here:** because clip manifests point at the multivariant
+  segments, clips get adaptive bitrate with no extra work.
+
+### PBP sync (TGF-339 sibling)
+
+Play-by-play sync needs a **game-clock → media-time** mapping. That mapping is a
+data concern (a per-game offset table relating PBP timestamps to media
+position), independent of delivery; it is noted here as a consumer of the same
+clip endpoint and is scoped in its own story rather than designed in this spike.
+
+## 5. What stays the same
+
+- The Worker gateway, its HS256 verify, signed-cookie mechanics, Range/scrubbing
+  handling, and CORS — extended (session scope, ABR paths), not rewritten.
+- The Django playback API (TGF-360) — gains a session endpoint and a clip
+  endpoint alongside the existing per-game one.
+- The player (vidstack/hls.js) — consumes multivariant manifests and clip
+  manifests with **no change** (ADR-0008 anticipated this).
+- Local-first development — the whole stack still runs under `wrangler dev` +
+  Miniflare R2 with zero cloud spend; ABR packaging and clip manifests are
+  exercised locally exactly as the v1 PoC was.
+
+## Open questions for implementation stories
+
+1. Exact ladder bitrates/codec profiles — tune against a sample of real games.
+2. Boundary-segment trimming: ship segment-granularity v1.5, or include the
+   ≤2-segment remux from the start? (Recommend: defer.)
+3. Session-token entitlement shape — leagues vs teams vs subscription tier —
+   needs the subscription model (not yet built) to firm up.
+4. Transcode host — workstation vs Fargate spot — a cost/convenience call made
+   at backfill time.

--- a/docs/video-scale/comparison.md
+++ b/docs/video-scale/comparison.md
@@ -1,0 +1,169 @@
+# Video delivery at scale — build vs buy (TGF-338)
+
+_Spike deliverable 1 of 4. Companion to [ADR-0009](https://github.com/Thistle-Grow-Software/griddy-web-portal/blob/main/docs/adr/0009-v15-video-delivery-scale.md) (the decision), [migration-plan.md](./migration-plan.md), and [backend-design.md](./backend-design.md)._
+
+This document compares the four delivery stacks named in TGF-338 — **Mux**,
+**Cloudflare Stream**, **self-hosted R2 + Worker** (the v1 stack, extended),
+and **self-hosted AWS (S3 + CloudFront + MediaConvert)** — on cost, developer
+experience, feature fit, and operational burden, and identifies the crossover
+points. It answers ticket questions #1, #2, #4, and #5.
+
+## TL;DR
+
+For **this** catalog — large (~2.95 TiB), static history, already 99% H.264/AAC,
+served from inside the Cloudflare ecosystem with free egress — **extending the
+self-hosted R2 + Worker stack wins at every viewing volume.** Managed services
+(Mux, CF Stream) and AWS CloudFront all start at a higher fixed cost and grow
+with delivered minutes; R2 stays flat at roughly **$120/mo** because egress is
+free and storage is cheap. The managed services' value (turnkey transcoding,
+bundled analytics) does not offset a 3–5× monthly premium for a catalog that
+transcodes **once** and never churns.
+
+The one piece worth buying is **player analytics** (Mux Data), which is sold
+decoupled from delivery, has a free tier, and works with the existing
+hls.js/vidstack player — so we get QoS metrics without the delivery premium.
+
+## Catalog sizing assumptions
+
+All figures are projected to ~1.5× accuracy — enough to separate "$100/mo" from
+"$1,000/mo", per the same bar the v1 cost model used.
+
+| Input | Value | Basis |
+| --- | --- | --- |
+| Catalog size on disk | 2.95 TiB (~3,242 GB) | `video_stats.md` (TGF-337) |
+| Games | ~1,204 | TGF-337 catalog report |
+| Catalog content-minutes | **~120,000 min (~2,000 hr)** | 3,242 GB ÷ ~27 MB/min mean (bitrate centroid ~2–3 Mbps, weighted to the 0.5–1 Mbps SD majority); ~1.5× estimate |
+| Mean watched minutes / stream | ~30 min | PoC condensed game ran 32 min; users watch portions |
+| ABR ladder storage multiple | ~2–2.5× source | 240/480/720/1080 renditions vs single remux (v1 was ~1×) |
+
+**Viewing-volume scenarios** (carried from the v1 cost model, now expressed in
+delivered minutes at ~30 min/stream):
+
+| Scenario | Streams/mo | Delivered min/mo |
+| --- | --- | --- |
+| Pilot | 100 | 3,000 |
+| Small | 1,000 | 30,000 |
+| Active | 10,000 | 300,000 |
+| Heavy | 100,000 | 3,000,000 |
+
+## Published pricing used (USD, early 2026)
+
+Prices drift; treat as order-of-magnitude. Sources are each vendor's public
+pricing page as of the spike.
+
+| Stack | Storage | Delivery / egress | Transcode | Notes |
+| --- | --- | --- | --- | --- |
+| **R2 + Worker** | $0.015/GB-mo | **$0** egress | one-time batch (own compute) | Workers $5/mo + $0.30/M reqs >10M; Class B reads $0.36/M |
+| **CF Stream** | $5 / 1,000 min stored-mo | $1 / 1,000 min delivered | included | Bills on source minutes; renditions managed for you |
+| **Mux Video** | ~$0.003/min-mo (encoded) | ~$0.001/min delivered | ~$0.0072/min one-time encode | Mux Data analytics sold separately (free < 100k views/mo) |
+| **AWS** | S3 $0.023/GB-mo | CloudFront ~$0.085/GB egress | MediaConvert ~$0.0075–0.015/min | Egress is the dominant term |
+
+## Projected monthly cost
+
+ABR-ladder storage is taken as ~6–7.5 TB for the self-hosted stacks (renditions
++ retained originals). Delivered GB assumes ~22.5 MB/min (~3 Mbps avg
+rendition).
+
+| Scenario | R2 + Worker | CF Stream | Mux Video | AWS (S3+CF) |
+| --- | --- | --- | --- | --- |
+| **Pilot** (3k min) | **~$120** | ~$603 | ~$363 | ~$146 |
+| **Small** (30k min) | **~$120** | ~$630 | ~$390 | ~$197 |
+| **Active** (300k min) | **~$121** | ~$900 | ~$660 | ~$714 |
+| **Heavy** (3M min) | **~$145** | ~$3,600 | ~$3,360 | ~$5,878 |
+| One-time transcode | ~$300–500 | included | ~$864 | ~$900–1,800 |
+| Fixed storage floor | ~$115/mo | ~$600/mo | ~$360/mo | ~$140/mo |
+
+### Reading the table
+
+- **R2 is flat.** Storage dominates and is fixed; reads/Workers stay in the
+  single-to-low-double digits even at 100k streams because R2 reads are
+  $0.36/M and egress is free. This is the same dynamic the v1 cost model found,
+  carried forward with a larger (ABR) storage base.
+- **CF Stream and Mux are storage-bound at low volume.** Their per-stored-minute
+  pricing puts the floor at $360–600/mo *before anyone watches anything* — 3–5×
+  the entire R2 bill. They only approach parity-of-growth at Heavy volume, and
+  even then they are 20–30× more expensive in absolute terms.
+- **AWS is cheapest among the alternatives at Pilot/Small but the worst at
+  scale** — CloudFront egress grows linearly with delivered minutes and crosses
+  R2 between Small and Active, reaching ~40× R2 at Heavy.
+
+### Crossover points
+
+- There is **no viewing volume at which any alternative beats R2** for this
+  catalog. R2's storage-only floor (~$115/mo) sits *below* the managed services'
+  storage-only floors ($360–600/mo), and its marginal delivery cost is ~$0.
+- AWS's *fixed* cost (~$140/mo) is within ~20% of R2's, but its *marginal* cost
+  (egress) makes the total cross above R2 at roughly **40,000 delivered min/mo
+  (~Small+)** and diverge sharply after.
+- The managed services would only win if the catalog were **small and churning**
+  (storage cheap, transcoding frequent) — the opposite of Griddy's static
+  archive — or if their bundled features were independently worth the premium
+  (addressed below).
+
+## Developer experience
+
+| Stack | DX | Verdict |
+| --- | --- | --- |
+| **Mux** | Best in class. Upload → playback URL in one API call; dashboard, signed playback, Data analytics, clipping API all turnkey. | Highest, but we have already built the equivalent gate/packaging for v1. |
+| **CF Stream** | Strong; single API, native to our Cloudflare account, Stream Player included. | High; least-effort *managed* option given we are already on Cloudflare. |
+| **R2 + Worker** | We own it. v1 already shipped the Worker gate, signed cookie, CORS, and `-c copy` packaging. Marginal DX cost for v1.5 is the ABR ladder + clip service. | Moderate up-front, zero vendor lock-in. The hard parts are done. |
+| **AWS** | Heaviest. MediaConvert job templates, CloudFront signed cookies, OAC, S3 lifecycle — most moving parts. | Lowest; only justified if live streaming (MediaLive) were on the roadmap. It is not. |
+
+## Feature fit (v1.5 needs)
+
+| Need (ticket) | Mux | CF Stream | R2 + Worker | AWS |
+| --- | --- | --- | --- | --- |
+| **ABR ladders** (240/480/720/1080) | Automatic | Automatic | Batch transcode (one-time); player already consumes multi-rendition manifests (ADR-0008) | MediaConvert |
+| **Clip playback across catalog** (TGF-339) | Clipping API (per-asset; cross-asset is manual) | Clipping (per-video) | **Synthesized clip-manifest** over stored segments — no re-encode, no new storage (see backend-design.md) | Manual (packager + manifest gen) |
+| **Analytics / QoS** (#5) | Mux Data (best) | Stream analytics (good) | Build, or bolt on **Mux Data standalone** | Build (CloudFront logs + own pipeline) |
+| **Signed access at scale** (#7) | Signed playback tokens | Signed URLs / tokens | Existing Django-token → Worker → signed-cookie; extend to session/entitlement scope | CloudFront signed cookies |
+| **DRM** (#4) | Add-on (Widevine/FairPlay/PlayReady) | Add-on | Not built | SPEKE + DRM vendor |
+
+**Clip generation (#6)** is the deciding feature for TGF-339 and the one place
+self-hosting is *better*, not just cheaper: because we own the segment store, a
+clip is a **generated HLS media playlist** that references the existing ABR
+segments overlapping `[start, end]` — zero new storage, zero re-encode, segment
+(~6 s) granularity for v1.5 with optional boundary trimming later. The managed
+clipping APIs are per-asset and would force either re-rendering each clip
+(storage/compute blow-up, the "server-side concat" anti-pattern the ticket
+flags) or paying to store derived clips. Detailed in
+[backend-design.md](./backend-design.md).
+
+## DRM (#4) — decision: defer
+
+The v1.5 catalog is owned/coaching and archival football film, not licensed
+broadcast content. The signed-cookie gate (entitlement enforced in Django,
+verified per-request at the Worker) is the appropriate control. **DRM is
+deferred.** Revisit only if Griddy licenses third-party broadcast footage whose
+rights contract mandates it — at which point Mux/CF Stream's DRM add-on becomes a
+reason to put *that subset* on a managed origin, not a reason to re-platform the
+whole catalog.
+
+## Analytics & QoS (#5) — bar for v1.5
+
+Track per playback session: **startup time, rebuffer ratio, completion rate,
+fatal error rate**, plus rendition/bandwidth distribution. Self-hosting delivery
+does not mean building analytics: **Mux Data** is sold standalone, integrates
+with hls.js/vidstack via a small SDK, and is free under ~100k monthly views —
+covering Pilot through Active for ~$0. This is the recommended way to hit the QoS
+bar without taking on the delivery premium.
+
+## Ops burden
+
+| Stack | Ongoing ops |
+| --- | --- |
+| **R2 + Worker** | A Worker deploy + an R2 bucket (both already in v1). Batch transcode is one-time for a static catalog. Lowest *ongoing* burden precisely because nothing recurs. |
+| **CF Stream / Mux** | Near-zero ops, but a recurring bill and a vendor dependency for the core product surface. |
+| **AWS** | Highest: MediaConvert templates, CloudFront distributions/invalidation, signed-cookie key rotation, S3 lifecycle. |
+
+The ops argument for "buy" is strongest when transcoding is **continuous** —
+i.e. once user-generated uploads land. That is out of scope for v1.5 (the
+catalog is fixed) but is the documented trigger to revisit (see ADR-0009).
+
+## Recommendation
+
+**Extend the self-hosted R2 + Worker stack for v1.5.** Add a one-time ABR
+transcode pass, build the clip-manifest service in-house, and adopt **Mux Data**
+for player QoS. Keep **Mux Video** documented as the escape hatch for the day
+user uploads create a persistent transcode pipeline. Rationale and consequences
+are recorded in [ADR-0009](https://github.com/Thistle-Grow-Software/griddy-web-portal/blob/main/docs/adr/0009-v15-video-delivery-scale.md).

--- a/docs/video-scale/index.md
+++ b/docs/video-scale/index.md
@@ -1,0 +1,37 @@
+# Video delivery at scale (v1.5) — TGF-338 spike
+
+Investigation and design output for **TGF-338 — _Spike: Video delivery
+infrastructure at scale (v1.5 prerequisite)_**. Where the v1 spike (TGF-337,
+`docs/video-poc/`) answered "how do we serve the existing film at all", this
+spike answers "how do we serve it at scale, with ABR, analytics, and
+cross-catalog clip playback, without re-platforming".
+
+The headline decision — **extend the self-hosted R2 + Worker stack rather than
+move to Mux or Cloudflare Stream** — is recorded as an ADR in the portal repo
+(ADRs live there, next to ADR-0008):
+[ADR-0009 — v1.5 video delivery at scale](https://github.com/Thistle-Grow-Software/griddy-web-portal/blob/main/docs/adr/0009-v15-video-delivery-scale.md).
+
+## Documents
+
+| Deliverable | Doc | Answers ticket Q |
+| --- | --- | --- |
+| Build-vs-buy comparison (cost, DX, feature fit, ops) | [comparison.md](./comparison.md) | #1, #2, #4, #5 |
+| Migration plan v1 → v1.5 | [migration-plan.md](./migration-plan.md) | #8 |
+| Backend design sketch (ingest, storage, signed URLs, clips) | [backend-design.md](./backend-design.md) | #3, #6, #7 |
+| ADR (v1.5 direction + rationale) | [ADR-0009 ↗](https://github.com/Thistle-Grow-Software/griddy-web-portal/blob/main/docs/adr/0009-v15-video-delivery-scale.md) | decision |
+
+Follow-up implementation epic and stories are filed in Jira and linked from
+TGF-338.
+
+## One-paragraph summary
+
+For a large, static, already-HLS-friendly catalog served with free egress from
+Cloudflare, self-hosted R2 + Worker delivery stays flat at ~$120/mo at every
+viewing volume, while Mux, Cloudflare Stream, and AWS CloudFront all start higher
+and grow with delivered minutes — there is no volume at which they win. So v1.5
+**extends** v1: a one-time ABR transcode backfill, a session-scoped access token
+for cross-catalog browsing, a synthesized **clip-manifest service** that plays
+arbitrary time ranges over the already-stored segments with no re-encode and no
+new storage (unblocking TGF-339), and **Mux Data** bolted on for player QoS.
+Managed **Mux Video** is kept as the documented escape hatch for the day
+user-generated uploads create a persistent transcode pipeline.

--- a/docs/video-scale/migration-plan.md
+++ b/docs/video-scale/migration-plan.md
@@ -1,0 +1,119 @@
+# Migration plan — v1 → v1.5 video delivery (TGF-338)
+
+_Spike deliverable 2 of 4. Companion to [comparison.md](./comparison.md),
+[backend-design.md](./backend-design.md), and
+[ADR-0009](https://github.com/Thistle-Grow-Software/griddy-web-portal/blob/main/docs/adr/0009-v15-video-delivery-scale.md)._
+
+Answers ticket question #8: how do we move from the v1 delivery stack (TGF-337 /
+ADR-0008) to v1.5 **without breaking existing users**? Because the v1.5 decision
+is to *extend* the v1 stack rather than re-platform onto a managed service, this
+is an additive, zero-downtime migration — no data leaves Cloudflare, no URLs are
+invalidated, and every step is independently reversible.
+
+## What v1 is (the starting point)
+
+| Piece | Where | v1 behavior |
+| --- | --- | --- |
+| Storage | R2 `griddy-video` | One **single-rendition** `-c copy` remux per game: `games/{id}/master.m3u8` + `init.mp4` + `seg_*.m4s` |
+| Gate | Worker (TGF-361) | Validates a **per-game** HS256 token → sets a per-game path-scoped signed cookie → streams objects |
+| API | Django (TGF-360) | `GET /api/games/{id}/playback` → manifest URL + per-game token |
+| Player | vidstack/hls.js (TGF-335) | Consumes the manifest; native HLS fallback on Safari |
+
+Everything is single-vendor (Cloudflare) and local-first reproducible.
+
+## Migration principle: additive, never destructive
+
+The v1.5 storage layout (see backend-design.md) **adds** rung directories and a
+multivariant `master.m3u8` while **retaining** the v1 single-rendition manifest
+as `master.v1.m3u8`. The v1 token/cookie path keeps working unchanged. Nothing
+is deleted or renamed, so a half-migrated catalog is fully playable: migrated
+games serve ABR, not-yet-migrated games serve the v1 single rendition, and the
+player handles both with no code change.
+
+## Phases
+
+### Phase 0 — Prerequisite: promote v1 to real Cloudflare
+
+v1's PoC runs against local Miniflare R2. Production v1.5 needs a real R2 bucket
+and the `video.griddy.football` Worker origin. This is the binding/config-only
+promotion ADR-0008 anticipated (and that TGF-340's apex-domain work feeds). It is
+a v1 deployment step, listed here because it gates everything below. **No v1.5
+code depends on it being done first beyond having a real origin to package into.**
+
+### Phase 1 — ABR packaging backfill (additive write)
+
+- Generalize the TGF-362 packager to the 4-rung ladder (`package_game --ladder
+  abr`).
+- Run the one-time backfill, **writing new rung objects and a new multivariant
+  `master.m3u8`** alongside the existing v1 objects. Copy the existing v1
+  `master.m3u8` to `master.v1.m3u8` *before* overwriting it, so the old manifest
+  survives.
+- Idempotent and resumable (deterministic keys, `PackagedRendition` rows).
+- **User impact: none.** No URL changes; the multivariant master is a superset.
+  A game that has been backfilled simply gains lower/higher rungs the player can
+  now choose between.
+
+### Phase 2 — Session-scoped access (additive gate change)
+
+- Add the Django **session endpoint** and the Worker **entitlement check** for
+  the new `ent`-claim token (backend-design.md §3). The existing per-game token
+  path is untouched — the Worker simply learns a second valid credential shape.
+- **User impact: none.** Existing per-game playback continues on the old token;
+  the session token is only exercised by new clip surfaces.
+
+### Phase 3 — Clip-manifest service (new surface)
+
+- Add `GET /api/games/{id}/clip.m3u8?start=&end=` (Django generates, Worker
+  gates) over the already-stored ABR segments.
+- Wire TGF-339's filtered-clip UI to it. This is **net-new functionality**, not a
+  migration of anything existing.
+
+### Phase 4 — Player QoS (additive instrumentation)
+
+- Add the **Mux Data** SDK to the vidstack/hls.js player for startup time,
+  rebuffer ratio, completion, and error metrics (comparison.md §Analytics).
+- **User impact: none** beyond an analytics beacon.
+
+### Phase 5 — Cutover & cleanup (deferred, optional)
+
+Once the whole catalog is backfilled and ABR has been validated in production for
+a soak period:
+
+- Point any remaining direct references at the multivariant `master.m3u8`.
+- Optionally retire `master.v1.m3u8` **only after** logs show no traffic to it.
+  Until then it costs ~nothing (one small text object/game) and is the rollback
+  anchor — there is no urgency to delete it.
+
+## Rollback
+
+Each phase reverts independently because nothing is destructive:
+
+| If this breaks… | Roll back by… |
+| --- | --- |
+| ABR backfill (Phase 1) | Serving `master.v1.m3u8` (point the API/player back at the single rendition); rung objects are inert if unreferenced |
+| Session gate (Phase 2) | Worker still accepts v1 per-game tokens; disable the session endpoint |
+| Clip service (Phase 3) | Feature-flag the clip UI off; no impact on full-game playback |
+| QoS (Phase 4) | Remove the analytics SDK init |
+
+The v1 single-rendition fallback the ADR-0008 author kept ("serve raw
+progressive MP4… it remains the fallback") still exists beneath all of this.
+
+## Migration risks & mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Backfill storage roughly triples footprint mid-run | Storage is ~$0.015/GB-mo and egress-free; even the doubled ~7 TB is ~$115/mo (comparison.md). Backfill in batches; monitor bucket size. |
+| A re-encoded rung diverges from the source (quality regression) | `PackagedRendition` records per-object checksums + ffmpeg version; spot-check a sample per league against the source before retiring v1 manifests. |
+| Session-token entitlement bug grants over-broad access | Entitlement is single-sourced in Django; default-deny in the Worker; short cookie TTL bounds blast radius; cover with the same Playwright auth-gate matrix the v1 PoC used (authorized 200, tampered/empty/wrong-scope 403). |
+| Player picks a too-high rung on slow connections | hls.js ABR handles this automatically once the ladder exists; QoS metrics (Phase 4) confirm rebuffer ratio in the field. |
+
+## Success criteria
+
+- Every backfilled game plays ABR in Chrome, Firefox, and Safari with no change
+  to its playback URL.
+- A pre-migration v1 playback URL still plays after migration (no broken links).
+- An unauthorized or wrong-entitlement request to any object returns 403 with no
+  media (parity with the v1 gate guarantee).
+- A clip request returns a playable manifest referencing only stored segments
+  (no new media objects created).
+- Catalog-wide R2 cost stays in the ~$100s/mo class projected in comparison.md.


### PR DESCRIPTION
Closes TGF-338